### PR TITLE
Add AI-assisted inventory generation

### DIFF
--- a/lib/cloud_functions/cloud_functions.dart
+++ b/lib/cloud_functions/cloud_functions.dart
@@ -29,4 +29,31 @@ class CloudFunctions {
       throw Exception('Cloud Run call failed: ${response.body}');
     }
   }
+
+  static Future<void> generateCourseInventory(String courseId) async {
+    final user = FirebaseAuth.instance.currentUser;
+    final idToken = await user?.getIdToken();
+
+    if (idToken == null) {
+      throw Exception('User not authenticated');
+    }
+
+    final response = await http
+        .post(
+          Uri.parse(
+              'https://learning-lab-server-kofwkwjq5q-uc.a.run.app/api/generate-course-inventory'),
+          headers: {
+            'Authorization': 'Bearer $idToken',
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({'courseId': courseId}),
+        )
+        .timeout(const Duration(minutes: 10));
+
+    if (response.statusCode != 200) {
+      print('Cloud Run call failed: ${response.statusCode}');
+      print('Response body: ${response.body}');
+      throw Exception('Cloud Run call failed: ${response.body}');
+    }
+  }
 }

--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -21,6 +21,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inv
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
+import 'package:social_learning/cloud_functions/cloud_functions.dart';
 
 class CourseDesignerInventoryPage extends StatefulWidget {
   const CourseDesignerInventoryPage({super.key});
@@ -205,6 +206,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage>
     inventoryEntries.add(
       AddNewCategoryEntry(
         onAdd: (name) => _onAddNewCategory(courseId, name),
+        onGenerate: _onGenerateInventory,
         contextData: this,
       ),
     );
@@ -306,5 +308,18 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage>
     });
 
     setState(() {});
+  }
+
+  Future<void> _onGenerateInventory() async {
+    if (_courseId == null) return;
+
+    setState(() => isLoading = true);
+    try {
+      await CloudFunctions.generateCourseInventory(_courseId!);
+    } catch (e, stack) {
+      print('Failed to generate inventory: $e\n$stack');
+    }
+
+    await loadInventoryData(_courseId!);
   }
 }


### PR DESCRIPTION
## Summary
- allow AI generation of categories and items
- implement API call to backend to generate course inventory
- show dialog before calling AI generator

## Testing
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a77a5c080832e80cf5ac89587b9fa