### PR TITLE
Update inventory generator to use new cloud service

### DIFF
--- a/lib/cloud_functions/cloud_functions.dart
+++ b/lib/cloud_functions/cloud_functions.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
+import '../data/course.dart';
+import '../data/course_profile.dart';
 
 class CloudFunctions {
   static Future<void> generateCourseFromPlan(String coursePlanId) async {
@@ -30,7 +32,8 @@ class CloudFunctions {
     }
   }
 
-  static Future<void> generateCourseInventory(String courseId) async {
+  static Future<void> generateCourseInventory(
+      Course course, CourseProfile? profile) async {
     final user = FirebaseAuth.instance.currentUser;
     final idToken = await user?.getIdToken();
 
@@ -41,12 +44,23 @@ class CloudFunctions {
     final response = await http
         .post(
           Uri.parse(
-              'https://learning-lab-server-kofwkwjq5q-uc.a.run.app/api/generate-course-inventory'),
+              'https://learning-lab-server-kofwkwjq5q-uc.a.run.app/api/generate-teachable-items'),
           headers: {
             'Authorization': 'Bearer $idToken',
             'Content-Type': 'application/json',
           },
-          body: jsonEncode({'courseId': courseId}),
+          body: jsonEncode({
+            'title': course.title,
+            'description': course.description,
+            'topicAndFocus': profile?.topicAndFocus,
+            'scheduleAndDuration': profile?.scheduleAndDuration,
+            'targetAudience': profile?.targetAudience,
+            'groupSizeAndFormat': profile?.groupSizeAndFormat,
+            'location': profile?.location,
+            'howStudentsJoin': profile?.howStudentsJoin,
+            'toneAndApproach': profile?.toneAndApproach,
+            'anythingUnusual': profile?.anythingUnusual,
+          }),
         )
         .timeout(const Duration(minutes: 10));
 

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart
@@ -2,6 +2,8 @@ import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/data/teachable_item_category.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/course_profile.dart';
 
 abstract class InventoryContext {
   /// All categories in the course (ordered by sortOrder)
@@ -18,4 +20,10 @@ abstract class InventoryContext {
 
   /// The flattened list of inventory UI entries (categories, items, add-new rows, etc.)
   List<InventoryEntry> getInventoryEntries();
+
+  /// The course that owns the inventory
+  Course? getCourse();
+
+  /// Optional course profile with additional metadata
+  CourseProfile? getCourseProfile();
 }


### PR DESCRIPTION
## Summary
- extend `InventoryContext` with course info
- load `CourseProfile` alongside inventory data
- call new Google Cloud endpoint with detailed course parameters

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ab5ed2918832e9244771acbd95a40