### PR TITLE
Implement client-side inventory generation saving

### DIFF
--- a/lib/cloud_functions/cloud_functions.dart
+++ b/lib/cloud_functions/cloud_functions.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
 import '../data/course.dart';
 import '../data/course_profile.dart';
+import 'inventory_generation_response.dart';
 
 class CloudFunctions {
   static Future<void> generateCourseFromPlan(String coursePlanId) async {
@@ -32,7 +33,7 @@ class CloudFunctions {
     }
   }
 
-  static Future<void> generateCourseInventory(
+  static Future<InventoryGenerationResponse> generateCourseInventory(
       Course course, CourseProfile? profile) async {
     final user = FirebaseAuth.instance.currentUser;
     final idToken = await user?.getIdToken();
@@ -69,5 +70,8 @@ class CloudFunctions {
       print('Response body: ${response.body}');
       throw Exception('Cloud Run call failed: ${response.body}');
     }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    return InventoryGenerationResponse.fromJson(decoded);
   }
 }

--- a/lib/cloud_functions/inventory_generation_response.dart
+++ b/lib/cloud_functions/inventory_generation_response.dart
@@ -1,0 +1,28 @@
+class GeneratedCategory {
+  final String category;
+  final List<String> items;
+
+  GeneratedCategory({required this.category, required this.items});
+
+  factory GeneratedCategory.fromJson(Map<String, dynamic> json) {
+    final itemsJson = json['items'] as List<dynamic>?;
+    return GeneratedCategory(
+      category: json['category'] as String? ?? '',
+      items: itemsJson?.map((e) => e.toString()).toList() ?? [],
+    );
+  }
+}
+
+class InventoryGenerationResponse {
+  final List<GeneratedCategory> categories;
+
+  InventoryGenerationResponse({required this.categories});
+
+  factory InventoryGenerationResponse.fromJson(Map<String, dynamic> json) {
+    final categoriesJson = json['categories'] as List<dynamic>? ?? [];
+    final categories = categoriesJson
+        .map((e) => GeneratedCategory.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return InventoryGenerationResponse(categories: categories);
+  }
+}

--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -59,6 +59,30 @@ class TeachableItemCategoryFunctions {
       return null;
     }
   }
+  static Future<List<TeachableItemCategory>> bulkCreateCategories({
+    required String courseId,
+    required List<String> names,
+  }) async {
+    final courseRef = _firestore.collection('courses').doc(courseId);
+    final batch = _firestore.batch();
+    final collection = _firestore.collection(_collectionPath);
+    final docRefs = <DocumentReference>[];
+    for (int i = 0; i < names.length; i++) {
+      final docRef = collection.doc();
+      docRefs.add(docRef);
+      batch.set(docRef, {
+        'courseId': courseRef,
+        'name': names[i],
+        'sortOrder': i,
+        'createdAt': FieldValue.serverTimestamp(),
+        'modifiedAt': FieldValue.serverTimestamp(),
+      });
+    }
+    await batch.commit();
+    final snapshots = await Future.wait(docRefs.map((d) => d.get()));
+    return snapshots.where((s) => s.exists).map((s) => TeachableItemCategory.fromSnapshot(s)).toList();
+  }
+
 
 
   static Future<void> updateCategory({

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/teachable_item_tag.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/course_profile.dart';
+import 'package:social_learning/cloud_functions/inventory_generation_response.dart';
 
 abstract class InventoryContext {
   /// All categories in the course (ordered by sortOrder)
@@ -26,4 +27,6 @@ abstract class InventoryContext {
 
   /// Optional course profile with additional metadata
   CourseProfile? getCourseProfile();
+
+  Future<void> saveGeneratedInventory(List<GeneratedCategory> generated);
 }


### PR DESCRIPTION
## Summary
- create `InventoryGenerationResponse` model for cloud inventory generation
- extend cloud function to return generated categories and items
- add bulk creation helpers for categories and items
- extend `InventoryContext` with `saveGeneratedInventory`
- implement saving generated inventory in course designer

## Testing
- `dart` and `flutter` not available so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_688d350db6cc832e9117ea3325e7d74a