### PR TITLE
Add CourseDesignerTheme for consistent header styling

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/course_designer_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class CourseDesignerCard extends StatefulWidget {
@@ -68,14 +69,14 @@ class _CourseDesignerCardState extends State<CourseDesignerCard> {
   Widget _buildHeader() {
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+      padding: CourseDesignerTheme.cardHeaderPadding,
       decoration: BoxDecoration(
         color: Colors.grey[100],
         borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
       ),
       child: Text(
         widget.title,
-        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        style: CourseDesignerTheme.cardHeaderTextStyle,
       ),
     );
   }

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 
 class InventoryIntroCard extends StatefulWidget {
   const InventoryIntroCard({super.key});
@@ -62,8 +63,11 @@ class _InventoryIntroCardState extends State<InventoryIntroCard> {
         color: Colors.grey[100],
         borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
       ),
-      padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
-      child: Text("Step 2: Inventory the Building Blocks", style: CustomTextStyles.subHeadline),
+      padding: CourseDesignerTheme.cardHeaderPadding,
+      child: Text(
+        "Step 2: Inventory the Building Blocks",
+        style: CourseDesignerTheme.cardHeaderTextStyle,
+      ),
     );
   }
 

--- a/lib/ui_foundation/ui_constants/course_designer_theme.dart
+++ b/lib/ui_foundation/ui_constants/course_designer_theme.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class CourseDesignerTheme {
+  static const EdgeInsets cardHeaderPadding =
+      EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0);
+
+  static const TextStyle cardHeaderTextStyle =
+      TextStyle(fontSize: 16, fontWeight: FontWeight.bold);
+}


### PR DESCRIPTION
## Summary
- provide `CourseDesignerTheme` with shared header padding and text style
- update `CourseDesignerCard` and `InventoryIntroCard` headers to use the new theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3689f964832ebf9cb47b73199d45