### PR TITLE
Add shared text field styling

### DIFF
--- a/lib/ui_foundation/course_create_page.dart
+++ b/lib/ui_foundation/course_create_page.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -89,34 +89,26 @@ class CourseCreateState extends State<CourseCreatePage> {
                                 padding: EdgeInsets.all(8),
                                 child: Column(children: [
                                   TextField(
-                                      decoration: InputDecoration(
+                                      decoration:
+                                          CustomUiConstants.getFilledInputDecoration(
+                                        context,
                                         labelText: 'Course Name',
-                                        errorText: courseNameError,
-                                        border: OutlineInputBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8.0),
-                                        ),
-                                      ),
+                                      ).copyWith(errorText: courseNameError),
                                       controller: courseNameController),
                                   SizedBox(height: 8),
                                   TextField(
-                                      decoration: InputDecoration(
+                                      decoration:
+                                          CustomUiConstants.getFilledInputDecoration(
+                                        context,
                                         labelText: 'Invitation Code',
-                                        errorText: invitationCodeError,
-                                        border: OutlineInputBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(8.0),
-                                        ),
-                                      ),
+                                      ).copyWith(errorText: invitationCodeError),
                                       controller: invitationCodeController),
                                   SizedBox(height: 8),
                                   TextField(
-                                    decoration: InputDecoration(
+                                    decoration:
+                                        CustomUiConstants.getFilledInputDecoration(
+                                      context,
                                       labelText: 'Description',
-                                      border: OutlineInputBorder(
-                                        borderRadius:
-                                            BorderRadius.circular(8.0),
-                                      ),
                                     ),
                                     controller: descriptionController,
                                     minLines: 5,

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
@@ -3,6 +3,7 @@ import 'package:social_learning/ui_foundation/course_designer_inventory_page.dar
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class AddNewCategoryEntry extends InventoryEntry {
   final Future<void> Function(String name) onAdd;
@@ -28,21 +29,10 @@ class AddNewCategoryEntry extends InventoryEntry {
             child: TextField(
               controller: controller,
               focusNode: focusNode,
-              decoration: InputDecoration(
+              decoration: CustomUiConstants.getFilledInputDecoration(
+                context,
                 labelText: 'Add new category...',
-                filled: true,
-                fillColor: Colors.grey[100],
-                contentPadding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: Colors.grey.shade400),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(
-                      color: Theme.of(context).colorScheme.primary, width: 2),
-                ),
+                enabledColor: Colors.grey.shade400,
               ),
               onSubmitted: (text) async {
                 final trimmed = text.trim();

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/ui_foundation/course_designer_inventory_page.dar
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class AddNewItemEntry extends InventoryEntry {
   final TeachableItemCategory category;
@@ -37,19 +38,10 @@ class AddNewItemEntry extends InventoryEntry {
           controller: controller,
           focusNode: focusNode,
           style: CustomTextStyles.getBody(context),
-          decoration: InputDecoration(
+          decoration: CustomUiConstants.getFilledInputDecoration(
+            context,
             labelText: 'New item',
-            filled: true,
-            fillColor: Colors.grey[100],
-            contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(6),
-              borderSide: BorderSide(color: Colors.grey.shade300),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(6),
-              borderSide: BorderSide(color: Theme.of(context).colorScheme.primary, width: 2),
-            ),
+            enabledColor: Colors.grey.shade300,
           ),
           onSubmitted: (text) async {
             final trimmed = text.trim();

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/data_helpers/teachable_item_tag_functions.d
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/color_picker_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class InventoryTagEditorDialog extends StatefulWidget {
   final List<TeachableItemTag> initialTags;
@@ -162,25 +163,11 @@ class _InventoryTagEditorDialogState extends State<InventoryTagEditorDialog> {
         Expanded(
           child: TextField(
             controller: _newTagController,
-            decoration: InputDecoration(
+            decoration: CustomUiConstants.getFilledInputDecoration(
+              context,
               labelText: 'New tag',
-              isDense: true,
-              filled: true,
-              fillColor: Colors.grey[100],
-              contentPadding:
-              const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(6),
-                borderSide: BorderSide(color: Colors.grey.shade300),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(6),
-                borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.primary,
-                  width: 2,
-                ),
-              ),
-            ),
+              enabledColor: Colors.grey.shade300,
+            ).copyWith(isDense: true),
             onSubmitted: (_) => _addNewTag(),
           ),
         ),

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/item_note_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/item_note_dialog.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/data_helpers/teachable_item_functions.dart'
 import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class ItemNoteDialog extends StatefulWidget {
   final TeachableItem item;
@@ -122,23 +123,17 @@ class _ItemNoteDialogState extends State<ItemNoteDialog> {
     return [
       TextFormField(
         controller: nameController,
-        decoration: InputDecoration(
+        decoration: CustomUiConstants.getFilledInputDecoration(
+          context,
           labelText: 'Item name',
-          filled: true,
-          fillColor: Colors.grey[100],
-          contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
       const SizedBox(height: 12),
       TextFormField(
         controller: noteController,
-        decoration: InputDecoration(
+        decoration: CustomUiConstants.getFilledInputDecoration(
+          context,
           labelText: 'Notes',
-          filled: true,
-          fillColor: Colors.grey[100],
-          contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
         ),
         maxLines: null,
         minLines: 5,

--- a/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_new_objective_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_new_objective_entry.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_learning_objectives/learning_objectives_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class AddNewObjectiveEntry extends StatefulWidget {
   final LearningObjectivesContext objectivesContext;
@@ -49,29 +50,14 @@ class _AddNewObjectiveEntryState extends State<AddNewObjectiveEntry> {
         child: TextFormField(
           controller: _controller,
           focusNode: _focusNode,
-          decoration: InputDecoration(
+          decoration: CustomUiConstants.getFilledInputDecoration(
+            context,
             labelText: 'Add new objective…',
-            filled: true,
-            fillColor: Colors.grey[100],
-            contentPadding:
-            const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: BorderSide(color: Colors.grey.shade300),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.primary, width: 2),
-            ),
-            errorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: const BorderSide(color: Colors.red),
-            ),
-            focusedErrorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: const BorderSide(color: Colors.red, width: 2),
-            ),
+            enabledColor: Colors.grey.shade300,
+          ).copyWith(
+            errorBorder: CustomUiConstants.getInputBorder(color: Colors.red),
+            focusedErrorBorder:
+                CustomUiConstants.getInputBorder(color: Colors.red, width: 2),
           ),
           validator: (value) {
             final trimmed = value?.trim() ?? '';

--- a/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_roster_widget.dart
+++ b/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_roster_widget.dart
@@ -10,6 +10,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
 import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_image_widget.dart';
 
 /// Roster widget that loads students lazily, allows sorting & filtering.
@@ -130,15 +131,13 @@ class InstructorDashboardRosterWidgetState
               // Search field
               Expanded(
                 child: TextField(
-                  decoration: InputDecoration(
+                  decoration: CustomUiConstants.getFilledInputDecoration(
+                    context,
                     hintText: 'Search students…',
+                    enabledColor: Colors.grey.shade300,
+                  ).copyWith(
                     prefixIcon: const Icon(Icons.search),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
                     isDense: true,
-                    contentPadding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                   ),
                   onChanged: (text) {
                     final f = text.trim();

--- a/lib/ui_foundation/helper_widgets/profile_lookup_widget.dart
+++ b/lib/ui_foundation/helper_widgets/profile_lookup_widget.dart
@@ -7,6 +7,7 @@ import 'package:social_learning/data/user.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_image_widget.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class ProfileLookupWidget extends StatefulWidget {
   final ApplicationState applicationState;
@@ -130,9 +131,9 @@ class ProfileLookupWidgetState extends State<ProfileLookupWidget> {
         // Search Input Field
         TextField(
           controller: _searchController,
-          decoration: const InputDecoration(
+          decoration: CustomUiConstants.getFilledInputDecoration(
+            context,
             hintText: 'Search for other students by name',
-            border: OutlineInputBorder(),
           ),
           onChanged: (text) => _onSearchChanged(),
         ),

--- a/lib/ui_foundation/helper_widgets/value_input_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/value_input_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class ValueInputDialog extends StatelessWidget {
   final String title;
@@ -33,13 +34,10 @@ class ValueInputDialog extends StatelessWidget {
                 ),
               TextField(
                 controller: controller,
-                decoration: InputDecoration(
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8.0),
-                  ),
+                decoration: CustomUiConstants.getFilledInputDecoration(
+                  context,
                   hintText: hintText,
-                  errorText: errorMessage,
-                ),
+                ).copyWith(errorText: errorMessage),
                 onChanged: (value) {
                   // Validate and update error message dynamically
                   errorMessage = validate?.call(value);

--- a/lib/ui_foundation/ui_constants/custom_ui_constants.dart
+++ b/lib/ui_foundation/ui_constants/custom_ui_constants.dart
@@ -25,6 +25,38 @@ class CustomUiConstants {
   static Padding getIndentationTextPadding(Widget widget) =>
       Padding(padding: const EdgeInsets.only(left: 8), child: widget);
 
+  /// Standard padding used for text field content.
+  static const EdgeInsets standardInputPadding =
+      EdgeInsets.symmetric(horizontal: 12, vertical: 10);
+
+  /// Returns an [OutlineInputBorder] with consistent radius and color.
+  static OutlineInputBorder getInputBorder(
+      {Color color = const Color(0xFFBDBDBD), double width = 1, double radius = 8}) {
+    return OutlineInputBorder(
+      borderRadius: BorderRadius.circular(radius),
+      borderSide: BorderSide(color: color, width: width),
+    );
+  }
+
+  /// Builds a filled [InputDecoration] using the application's standard style.
+  static InputDecoration getFilledInputDecoration(
+    BuildContext context, {
+    String? labelText,
+    String? hintText,
+    Color enabledColor = const Color(0xFFBDBDBD),
+  }) {
+    return InputDecoration(
+      labelText: labelText,
+      hintText: hintText,
+      filled: true,
+      fillColor: Colors.grey[100],
+      contentPadding: standardInputPadding,
+      enabledBorder: getInputBorder(color: enabledColor),
+      focusedBorder:
+          getInputBorder(color: Theme.of(context).colorScheme.primary, width: 2),
+    );
+  }
+
   static Widget getGeneralFooter(BuildContext context,
       {bool withDivider = true}) {
     return Column(


### PR DESCRIPTION
## Summary
- add `getInputBorder` and `getFilledInputDecoration` helpers
- use the shared style in AddNewItemEntry, AddNewCategoryEntry and more widgets
- fix mis-typed import path in `course_create_page`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d36903050832e9e0de32634cb565d