### PR TITLE
Add reusable CourseDesignerTheme button style

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
@@ -3,6 +3,7 @@ import 'package:social_learning/ui_foundation/course_designer_inventory_page.dar
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 
 class AddNewCategoryEntry extends InventoryEntry {
   final Future<void> Function(String name) onAdd;
@@ -77,6 +78,7 @@ class AddNewCategoryEntry extends InventoryEntry {
           ElevatedButton.icon(
             icon: const Icon(Icons.auto_fix_high),
             label: const Text('AI'),
+            style: CourseDesignerTheme.secondaryButtonStyle,
             onPressed: () => _onAIPressed(context),
           ),
         ],

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_activity_row.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/data/session_play_activity_type.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 
 class AddActivityRow extends StatefulWidget {
   final SessionPlanContext sessionPlanContext;
@@ -54,6 +55,7 @@ class _AddActivityRowState extends State<AddActivityRow> {
               ElevatedButton.icon(
                 icon: const Icon(Icons.add),
                 label: const Text("Add"),
+                style: CourseDesignerTheme.secondaryButtonStyle,
                 onPressed: () async {
                   await widget.sessionPlanContext.addActivity(
                     blockId: widget.sessionPlanBlockId,

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_block_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_block_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 
 class AddBlockRow extends StatelessWidget {
   final SessionPlanContext sessionPlanContext;
@@ -18,11 +19,7 @@ class AddBlockRow extends StatelessWidget {
               },
               icon: const Icon(Icons.add),
               label: const Text('Add New Block'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.grey.shade100,
-                foregroundColor: Colors.black87,
-                elevation: 0,
-              ),
+              style: CourseDesignerTheme.secondaryButtonStyle,
             ),
           ),
 

--- a/lib/ui_foundation/ui_constants/course_designer_theme.dart
+++ b/lib/ui_foundation/ui_constants/course_designer_theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Styling helpers specific to the course designer screens.
+class CourseDesignerTheme {
+  /// Standard style for less prominent [ElevatedButton]s.
+  static final ButtonStyle secondaryButtonStyle = ElevatedButton.styleFrom(
+    backgroundColor: Colors.grey.shade100,
+    foregroundColor: Colors.black87,
+    elevation: 0,
+  );
+}


### PR DESCRIPTION
## Summary
- add `CourseDesignerTheme` with `secondaryButtonStyle`
- reuse this style in course designer widgets

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d36c248f8832e84f01ad6ae378314