### PR TITLE
Apply CustomTextStyles across course designer widgets

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/course_designer_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class CourseDesignerCard extends StatefulWidget {
   final String title;
@@ -75,7 +76,7 @@ class _CourseDesignerCardState extends State<CourseDesignerCard> {
       ),
       child: Text(
         widget.title,
-        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        style: CustomTextStyles.getBodyEmphasized(context),
       ),
     );
   }

--- a/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class DecomposedCourseDesignerCard {
   static const _borderRadius = 8.0;
@@ -15,7 +16,7 @@ class DecomposedCourseDesignerCard {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Text(
         title,
-        style: const TextStyle(fontWeight: FontWeight.bold),
+        style: CustomTextStyles.subHeadline,
       ),
     );
   }
@@ -36,7 +37,7 @@ class DecomposedCourseDesignerCard {
           Expanded(
             child: Text(
               title,
-              style: const TextStyle(fontWeight: FontWeight.bold),
+              style: CustomTextStyles.subHeadline,
             ),
           ),
           ...icons.map((icon) => Padding(
@@ -64,6 +65,7 @@ class DecomposedCourseDesignerCard {
   }
 
   static Widget buildColorHighlightedBody({
+    required BuildContext context,
     required Widget child,
     required Color color,
     String? leadingText,
@@ -93,8 +95,7 @@ class DecomposedCourseDesignerCard {
                 alignment: Alignment.center,
                 child: Text(
                   leadingText,
-                  style: const TextStyle(
-                    // fontSize: 13,
+                  style: CustomTextStyles.getBody(context)?.copyWith(
                     fontWeight: FontWeight.w500,
                     color: Colors.black87,
                   ),

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart
@@ -73,21 +73,24 @@ class _InventoryIntroCardState extends State<InventoryIntroCard> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             "Brainstorm all the small, teachable pieces of your subject. "
                 "You're not creating lessons yet — just listing the core concepts and skills.\n\n"
                 "🎯 Example (chess):\n"
                 "• Movement → Bishop, Pawn, Knight\n"
                 "• Tactics → Fork, Pin\n"
                 "• Rules → Castling, En Passant",
-            style: TextStyle(fontSize: 13, color: Colors.black87),
+            style: CustomTextStyles.getBodyNote(context)?.copyWith(color: Colors.black87),
           ),
           const SizedBox(height: 8),
           Align(
             alignment: Alignment.centerRight,
             child: TextButton(
               onPressed: _dismissCardBody,
-              child: const Text("Dismiss", style: TextStyle(fontSize: 13)),
+              child: Text(
+                "Dismiss",
+                style: CustomTextStyles.getBodyNote(context),
+              ),
             ),
           )
         ],

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_card.dart
@@ -88,11 +88,10 @@ class _InventoryTagCardState extends State<InventoryTagCard> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 10.0),
       child: _localTags.isEmpty
-          ? const Text(
+          ? Text(
         'No tags yet. Create tags like "easy", "hard", or "optional" to categorize your items.',
-        style: TextStyle(
+        style: CustomTextStyles.getBodyNote(context)?.copyWith(
           color: Colors.grey,
-          fontSize: 13,
           fontStyle: FontStyle.italic,
         ),
       )

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/data_helpers/teachable_item_tag_functions.d
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/color_picker_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class InventoryTagEditorDialog extends StatefulWidget {
   final List<TeachableItemTag> initialTags;
@@ -95,7 +96,10 @@ class _InventoryTagEditorDialogState extends State<InventoryTagEditorDialog> {
 
           // Tag name
           Expanded(
-            child: Text(tag.tag.name, style: const TextStyle(fontSize: 14)),
+            child: Text(
+              tag.tag.name,
+              style: CustomTextStyles.getBody(context),
+            ),
           ),
 
           // Edit icon

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/item_note_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/item_note_dialog.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/data_helpers/teachable_item_functions.dart'
 import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_context.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class ItemNoteDialog extends StatefulWidget {
   final TeachableItem item;
@@ -182,10 +183,7 @@ class _ItemNoteDialogState extends State<ItemNoteDialog> {
         spans.add(
           TextSpan(
             text: url,
-            style: const TextStyle(
-              color: Colors.blue,
-              decoration: TextDecoration.underline,
-            ),
+            style: CustomTextStyles.getLink(context),
             recognizer: TapGestureRecognizer()
               ..onTap = () => launchUrlString(url),
           ),

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/tag_pill.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/tag_pill.dart
@@ -1,4 +1,5 @@
-  import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
   class TagPill extends StatelessWidget {
     final String label;
@@ -22,11 +23,9 @@
         ),
         child: Text(
           label,
-          style: TextStyle(
-            fontSize: 11,
-            height: 1,
-            color: textColor,
+          style: CustomTextStyles.getBodyTiny(context)?.copyWith(
             fontWeight: FontWeight.w500,
+            color: textColor,
           ),
         ),
       );

--- a/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_lesson_fanout_widget.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_lesson_fanout_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/teachable_item.dart';
@@ -64,8 +65,7 @@ class AddLessonFanoutWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Text(
               level.title,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
                 color: Colors.grey,
               ),
             ),
@@ -96,8 +96,7 @@ class AddLessonFanoutWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Text(
               'Other lessons',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
                 color: Colors.grey,
               ),
             ),

--- a/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_teachable_item_fanout_widget.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/add_teachable_item_fanout_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/teachable_item.dart';
@@ -65,8 +66,7 @@ class AddTeachableItemFanoutWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Text(
               category.name,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
                 color: Colors.grey,
               ),
             ),

--- a/lib/ui_foundation/helper_widgets/course_designer_prerequisites/add_prerequisite_fanout_widget.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_prerequisites/add_prerequisite_fanout_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class AddPrerequisiteFanoutWidget extends StatefulWidget {
   final PrerequisiteContext context;
@@ -104,8 +105,9 @@ class _AddPrerequisiteFanoutWidgetState
           padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 6),
           child: Text(
             category.name,
-            style:
-            const TextStyle(fontWeight: FontWeight.bold, color: Colors.grey),
+            style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
+              color: Colors.grey,
+            ),
           ),
         ),
       );
@@ -125,7 +127,7 @@ class _AddPrerequisiteFanoutWidgetState
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               child: Text(
                 item.name ?? '(Untitled)',
-                style: TextStyle(
+                style: CustomTextStyles.getBody(context)?.copyWith(
                   color: isDisabled ? Colors.grey.shade400 : Colors.black,
                 ),
               ),

--- a/lib/ui_foundation/helper_widgets/course_designer_prerequisites/focused_teachable_item_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_prerequisites/focused_teachable_item_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/data/teachable_item.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_context.dart';
 
@@ -56,10 +57,8 @@ class FocusedTeachableItemCard extends StatelessWidget {
                           enabled: false,
                           child: Text(
                             category.name,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.grey,
-                            ),
+                            style: CustomTextStyles.getBodyEmphasized(context)
+                                ?.copyWith(color: Colors.grey),
                           ),
                         ),
                         for (final item in this
@@ -78,16 +77,12 @@ class FocusedTeachableItemCard extends StatelessWidget {
               const SizedBox(width: 8),
               InkWell(
                 onTap: onShowItemsWithPrerequisites,
-                child: const Padding(
+                child: Padding(
                   padding:
-                      EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
+                      const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12.0),
                   child: Text(
                     'View All',
-                    style: TextStyle(
-                      color: Colors.blue,
-                      decoration: TextDecoration.underline,
-                      decorationColor: Colors.blue,
-                    ),
+                    style: CustomTextStyles.getLink(context),
                   ),
                 ),
               ),

--- a/lib/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_item_entry.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/data/teachable_item.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/add_prerequisite_fanout_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_context.dart';
@@ -102,7 +103,8 @@ class PrerequisiteItemEntry extends StatelessWidget {
           const SizedBox(width: 4),
           Text(
             item.name ?? '(Untitled)',
-            style: isRoot ? const TextStyle(fontWeight: FontWeight.bold) : null,
+            style:
+                isRoot ? CustomTextStyles.getBodyEmphasized(context) : null,
           ),
           ...tagWidgets,
           const SizedBox(width: 4),

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/add_activity_row.dart
@@ -29,6 +29,7 @@ class _AddActivityRowState extends State<AddActivityRow> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         DecomposedCourseDesignerCard.buildColorHighlightedBody(
+          context: context,
           color: _selectedType.color,
           leadingText: startTimeText,
           child: Row(

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/lesson_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/lesson_activity_row.dart
@@ -6,6 +6,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_ses
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
 import '../../../data/session_play_activity_type.dart';
 import '../course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class LessonActivityRow extends StatelessWidget {
   final SessionPlanActivity activity;
@@ -33,13 +34,11 @@ class LessonActivityRow extends StatelessWidget {
     }
   }
 
-  TextStyle _durationStyle() {
-    return TextStyle(
-      fontSize: 13,
+  TextStyle? _durationStyle(BuildContext context) {
+    return CustomTextStyles.getBodyNote(context)?.copyWith(
       color: activity.overrideDuration != null ? Colors.black : Colors.grey,
-      fontStyle: activity.overrideDuration != null
-          ? FontStyle.normal
-          : FontStyle.italic,
+      fontStyle:
+          activity.overrideDuration != null ? FontStyle.normal : FontStyle.italic,
     );
   }
 
@@ -98,6 +97,7 @@ class LessonActivityRow extends StatelessWidget {
     final color = SessionPlanActivityType.lesson.color;
 
     return DecomposedCourseDesignerCard.buildColorHighlightedBody(
+      context: context,
       color: color,
       leadingText: time,
       child: Padding(
@@ -107,7 +107,7 @@ class LessonActivityRow extends StatelessWidget {
             Expanded(
               child: Text(
                 'Lesson: ${lesson?.title ?? '(select a lesson)'}',
-                style: const TextStyle(fontSize: 14),
+                style: CustomTextStyles.getBody(context),
               ),
             ),
             InkWell(
@@ -118,7 +118,7 @@ class LessonActivityRow extends StatelessWidget {
                     const EdgeInsets.symmetric(horizontal: 6.0, vertical: 4.0),
                 child: Text(
                   _durationText(),
-                  style: _durationStyle(),
+                  style: _durationStyle(context),
                 ),
               ),
             ),

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/non_lesson_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/non_lesson_activity_row.dart
@@ -3,6 +3,7 @@ import 'package:social_learning/data/session_plan_activity.dart';
 import 'package:social_learning/data/session_play_activity_type.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class NonLessonActivityRow extends StatelessWidget {
   final SessionPlanActivity activity;
@@ -26,6 +27,7 @@ class NonLessonActivityRow extends StatelessWidget {
     final isOverride = overrideDuration != null;
 
     return DecomposedCourseDesignerCard.buildColorHighlightedBody(
+      context: context,
       color: color,
       leadingText: startTime,
       child: Padding(
@@ -35,8 +37,7 @@ class NonLessonActivityRow extends StatelessWidget {
             Expanded(
               child: Text(
                 '${activity.activityType.humanLabel}: $title',
-                style: TextStyle(
-                  fontSize: 14,
+                style: CustomTextStyles.getBody(context)?.copyWith(
                   fontStyle: title == '(enter name)' ? FontStyle.italic : FontStyle.normal,
                   color: title == '(enter name)' ? Colors.grey : Colors.black,
                 ),
@@ -89,8 +90,7 @@ class NonLessonActivityRow extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                 child: Text(
                   isOverride ? '$showDuration min' : '($defaultDuration min)',
-                  style: TextStyle(
-                    fontSize: 13,
+                  style: CustomTextStyles.getBodyNote(context)?.copyWith(
                     color: isOverride ? Colors.black : Colors.grey,
                     fontStyle: isOverride ? FontStyle.normal : FontStyle.italic,
                   ),

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/select_lesson_for_activity_fanout_widget.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/select_lesson_for_activity_fanout_widget.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/session_plan_activity.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class SelectLessonForActivityFanoutWidget {
   static void show({
@@ -47,8 +48,7 @@ class SelectLessonForActivityFanoutWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Text(
               level.title,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
                 color: Colors.grey,
               ),
             ),
@@ -84,8 +84,7 @@ class SelectLessonForActivityFanoutWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             child: Text(
               'Other lessons',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
+              style: CustomTextStyles.getBodyEmphasized(context)?.copyWith(
                 color: Colors.grey,
               ),
             ),

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_header_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_header_row.dart
@@ -4,6 +4,7 @@ import '../../../data/session_plan_block.dart';
 import '../course_designer/decomposed_course_designer_card.dart';
 import '../dialog_utils.dart';
 import '../value_input_dialog.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class SessionBlockHeaderRow extends StatelessWidget {
   final SessionPlanBlock block;
@@ -55,8 +56,7 @@ class SessionBlockHeaderRow extends StatelessWidget {
           padding: const EdgeInsets.only(right: 8.0), // space before real icons
           child: Text(
             durationStr,
-            style: const TextStyle(
-              fontWeight: FontWeight.normal,
+            style: CustomTextStyles.getBodyNote(context)?.copyWith(
               color: Colors.grey,
             ),
           ),

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_overview_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_overview_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:percent_indicator/flutter_percent_indicator.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 import '../course_designer/course_designer_card.dart';
 
@@ -16,9 +17,9 @@ class SessionPlanOverviewCard extends StatelessWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             "Plan your session minute-by-minute with lessons and other classroom activities (e.g. opening circle, breaks, etc.)",
-            style: TextStyle(fontSize: 14),
+            style: CustomTextStyles.getBody(context),
           ),
           const SizedBox(height: 16),
           Wrap(
@@ -44,7 +45,7 @@ class SessionPlanOverviewCard extends StatelessWidget {
                   Text(
                     objective.name ?? "Untitled",
                     textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 12),
+                    style: CustomTextStyles.getBodyNote(context),
                   ),
                 ],
               );

--- a/lib/ui_foundation/ui_constants/custom_text_styles.dart
+++ b/lib/ui_foundation/ui_constants/custom_text_styles.dart
@@ -24,6 +24,12 @@ class CustomTextStyles {
   static TextStyle? getBodySmall(BuildContext context) =>
       Theme.of(context).textTheme.bodySmall;
 
+  static TextStyle? getBodyTiny(BuildContext context) =>
+      Theme.of(context).textTheme.bodySmall?.copyWith(
+        fontSize: 11,
+        height: 1,
+      );
+
   static TextStyle? getPartiallyLearned(BuildContext context) =>
       getBody(context)?.copyWith(color: partiallyLearnedColor);
 


### PR DESCRIPTION
## Summary
- refactor course designer helper widgets to remove inline text styles
- use `CustomTextStyles` variants for row text, pills, and notes
- adjust widgets to pass context to `buildColorHighlightedBody`
- add tiny text style for tag pills to keep fonts small

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d36a1fa20832ea96c367e3b37ef28