### PR TITLE
Add CourseDesigner spacing theme

### DIFF
--- a/lib/ui_foundation/course_designer_intro_page.dart
+++ b/lib/ui_foundation/course_designer_intro_page.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer/cou
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -92,7 +93,7 @@ class _StepsBody extends StatelessWidget {
           'Blank pages are intimidating. This flow offers bite‑size prompts so you can plan faster and with less guess‑work.',
           style: base,
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingMedium),
         row('Inventory', 'brain dump teachable elements'),
         row('Prerequisites', 'sequence the learning'),
         row('Scope', 'flip items on/off to fit the time constraints'),
@@ -102,7 +103,7 @@ class _StepsBody extends StatelessWidget {
             'start with the result and work back to lessons'),
         row('Session outline',
             'drag lessons, breaks, and warm‑ups into a teaching agenda'),
-        const SizedBox(height: 8),
+        const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingSmall),
         Text(
           '(Jump between steps anytime from the left‑menu.)',
           style: CustomTextStyles.getBodyNote(context),

--- a/lib/ui_foundation/course_designer_learning_objectives_page.dart
+++ b/lib/ui_foundation/course_designer_learning_objectives_page.dart
@@ -15,6 +15,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_sco
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_items_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_overview_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -124,7 +125,7 @@ class _CourseDesignerLearningObjectivesPageState
                   child: Column(
                     children: [
                       LearningObjectivesOverviewCard(),
-                      const SizedBox(height: 24),
+                      const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingLarge),
                       // DecomposedCourseDesignerCard.buildHeader(
                       //     'Edit Learning Objectives'),
                     ],

--- a/lib/ui_foundation/course_designer_prerequisites_page.dart
+++ b/lib/ui_foundation/course_designer_prerequisites_page.dart
@@ -9,6 +9,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_pre
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_context.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -139,7 +140,7 @@ class _CourseDesignerPrerequisitesPageState
                     onShowItemsWithPrerequisites:
                         _handleShowItemsWithPrerequisites,
                   ),
-                  const SizedBox(height: 24),
+                  const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingLarge),
                   DecomposedCourseDesignerCard.buildHeader('Dependency Tree'),
                 ],
               ),

--- a/lib/ui_foundation/course_designer_profile_page.dart
+++ b/lib/ui_foundation/course_designer_profile_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart'
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -218,7 +219,8 @@ class _CourseDesignerProfilePageState extends State<CourseDesignerProfilePage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           for (int i = 0; i < fields.length; i++) ...[
-            if (i > 0) const SizedBox(height: 24),
+            if (i > 0)
+              const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingLarge),
             fields[i],
           ],
         ],
@@ -234,7 +236,7 @@ class _CourseDesignerProfilePageState extends State<CourseDesignerProfilePage> {
         Text(label, style: CustomTextStyles.getBodyEmphasized(context)),
         const SizedBox(height: 4),
         Text(help, style: CustomTextStyles.getBodyNote(context)),
-        const SizedBox(height: 12),
+        const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingMedium),
         TextField(
           controller: controller,
           maxLines: null,

--- a/lib/ui_foundation/course_designer_scope_page.dart
+++ b/lib/ui_foundation/course_designer_scope_page.dart
@@ -12,6 +12,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_sco
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_items_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_overview_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -123,7 +124,7 @@ class _CourseDesignerScopePageState extends State<CourseDesignerScopePage> {
               child: Column(
                 children: [
                   ScopeOverviewCard(scopeContext: _scopeContext!),
-                  const SizedBox(height: 24),
+                  const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingLarge),
                   DecomposedCourseDesignerCard.buildHeader(
                       'Select teachable items'),
                 ],

--- a/lib/ui_foundation/course_designer_session_plan_page.dart
+++ b/lib/ui_foundation/course_designer_session_plan_page.dart
@@ -7,6 +7,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_ses
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_overview_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_block_list_view.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/course_designer_theme.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -119,7 +120,7 @@ class _CourseDesignerSessionPlanPageState
               child: Column(
                 children: [
                   SessionPlanOverviewCard(context: _sessionPlanContext!),
-                  const SizedBox(height: 24),
+                  const SizedBox(height: CourseDesignerTheme.kCourseDesignerSpacingLarge),
                 ],
               ),
             ),

--- a/lib/ui_foundation/ui_constants/course_designer_theme.dart
+++ b/lib/ui_foundation/ui_constants/course_designer_theme.dart
@@ -1,0 +1,13 @@
+
+/// Theme constants for course designer pages.
+class CourseDesignerTheme {
+  /// Small vertical spacing.
+  static const double kCourseDesignerSpacingSmall = 8.0;
+
+  /// Medium vertical spacing.
+  static const double kCourseDesignerSpacingMedium = 12.0;
+
+  /// Large vertical spacing.
+  static const double kCourseDesignerSpacingLarge = 24.0;
+
+}


### PR DESCRIPTION
## Summary
- define `CourseDesignerTheme` with spacing constants
- apply spacing constants in CourseDesigner pages

## Testing
- `dart format -o none --set-exit-if-changed lib/ui_foundation/course_designer_intro_page.dart lib/ui_foundation/course_designer_profile_page.dart lib/ui_foundation/course_designer_prerequisites_page.dart lib/ui_foundation/course_designer_scope_page.dart lib/ui_foundation/course_designer_session_plan_page.dart lib/ui_foundation/course_designer_learning_objectives_page.dart lib/ui_foundation/ui_constants/course_designer_theme.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d36f933e4832eae3e5338264b806e