### PR TITLE
Replace raw Firestore doc builders with docRef helper

### DIFF
--- a/lib/data/course.dart
+++ b/lib/data/course.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class Course {
   String? id;
@@ -27,6 +28,5 @@ class Course {
         isPrivate = doc.data()?['isPrivate'] as bool? ?? false,
         invitationCode = doc.data()?['invitationCode'] as String?;
 
-  DocumentReference get docRef =>
-      FirebaseFirestore.instance.doc('/courses/$id');
+  DocumentReference get docRef => docRef('courses', id!);
 }

--- a/lib/data/course_plan.dart
+++ b/lib/data/course_plan.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class CoursePlan {
   String? id;
@@ -36,8 +37,7 @@ class CoursePlan {
     'created': created ?? FieldValue.serverTimestamp(),
   };
 
-  DocumentReference get docRef =>
-      FirebaseFirestore.instance.doc('/coursePlans/$id');
+  DocumentReference get docRef => docRef('coursePlans', id!);
 
   static CollectionReference<Map<String, dynamic>> get collection =>
       FirebaseFirestore.instance.collection('coursePlans');

--- a/lib/data/data_helpers/course_profile_functions.dart
+++ b/lib/data/data_helpers/course_profile_functions.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/course_profile.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class CourseProfileFunctions {
   static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -7,7 +8,7 @@ class CourseProfileFunctions {
 
   static Future<CourseProfile?> getCourseProfile(String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final querySnapshot = await _firestore
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)

--- a/lib/data/data_helpers/instructor_dashboard_functions.dart
+++ b/lib/data/data_helpers/instructor_dashboard_functions.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/user.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 /// Collection of helper functions for the Instructor Dashboard.
 class InstructorDashboardFunctions {
@@ -12,7 +13,7 @@ class InstructorDashboardFunctions {
   /// Returns null on error or if the count is unavailable.
   static Future<int?> getStudentCount(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
+      final courseRef = docRef('courses', courseId);
       final agg = await FirebaseFirestore.instance
           .collection('users')
           .where('enrolledCourseIds', arrayContains: courseRef)
@@ -30,7 +31,7 @@ class InstructorDashboardFunctions {
   /// Returns null on error or if the count is unavailable.
   static Future<int?> getLessonCount(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
+      final courseRef = docRef('courses', courseId);
       final agg = await FirebaseFirestore.instance
           .collection('lessons')
           .where('courseId', isEqualTo: courseRef)
@@ -89,8 +90,7 @@ class InstructorDashboardFunctions {
       return null;
     }
 
-    final userSnap =
-        await FirebaseFirestore.instance.collection('users').doc(topId).get();
+    final userSnap = await docRef('users', topId).get();
 
     print('Got most advanced student: ${userSnap.data()}');
     return userSnap.exists ? User.fromSnapshot(userSnap) : null;
@@ -111,7 +111,7 @@ class InstructorDashboardFunctions {
     StudentSortOption sort = StudentSortOption.alphabetical,
     String? nameFilter,
   }) async {
-    final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
+    final courseRef = docRef('courses', courseId);
     Query<Map<String, dynamic>> query = FirebaseFirestore.instance
         .collection('users')
         .where('enrolledCourseIds', arrayContains: courseRef);

--- a/lib/data/data_helpers/learning_objective_functions.dart
+++ b/lib/data/data_helpers/learning_objective_functions.dart
@@ -9,7 +9,7 @@ class LearningObjectiveFunctions {
   static Future<List<LearningObjective>> getObjectivesForCourse(
       String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final snapshot = await _firestore
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)
@@ -34,7 +34,7 @@ class LearningObjectiveFunctions {
     print(
         'LearningObjectiveFunctions: Saving objective: $id, courseId: $courseId, sortOrder: $sortOrder, name: $name, description: $description, teachableItemIds: $teachableItemIds');
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final data = {
         'courseId': courseRef,
         'sortOrder': sortOrder,
@@ -117,7 +117,7 @@ class LearningObjectiveFunctions {
     print(
         'Adding objective: courseId: $courseId, name: $name, sortOrder: $sortOrder');
     name = name.trim();
-    final courseRef = _firestore.collection('courses').doc(courseId);
+    final courseRef = docRef('courses', courseId);
     var docRef = await _firestore.collection(_collectionPath).add({
       'courseId': courseRef,
       'sortOrder': sortOrder,

--- a/lib/data/data_helpers/online_session_review_functions.dart
+++ b/lib/data/data_helpers/online_session_review_functions.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/online_session.dart';
 import 'package:social_learning/data/online_session_review.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class OnlineSessionReviewFunctions {
   static CollectionReference<Map<String, dynamic>> get _reviewCollection =>
@@ -9,8 +10,7 @@ class OnlineSessionReviewFunctions {
   static Future<void> createPendingReviewsForSession(
       OnlineSession session) async {
     // Build DocumentReferences for the session and lesson.
-    DocumentReference sessionRef =
-        FirebaseFirestore.instance.collection('onlineSessions').doc(session.id);
+    DocumentReference sessionRef = docRef('onlineSessions', session.id);
     DocumentReference? lessonRef = session.lessonId;
     if (lessonRef == null) {
       print(

--- a/lib/data/data_helpers/progress_video_functions.dart
+++ b/lib/data/data_helpers/progress_video_functions.dart
@@ -2,6 +2,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/progress_video.dart';
 import 'package:social_learning/data/user.dart';
@@ -33,11 +34,11 @@ class ProgressVideoFunctions {
     await FirebaseFirestore.instance
         .collection('progressVideos')
         .add(<String, dynamic>{
-      'userId': FirebaseFirestore.instance.doc('/users/${user.id}'),
+      'userId': docRef('users', user.id!),
       'userUid': user.uid,
       'courseId':
-          FirebaseFirestore.instance.doc('/courses/${lesson.courseId.id}'),
-      'lessonId': FirebaseFirestore.instance.doc('/lessons/${lesson.id}'),
+          docRef('courses', lesson.courseId.id),
+      'lessonId': docRef('lessons', lesson.id!),
       'youtubeUrl': youtubeUrl,
       'youtubeVideoId': extractYouTubeVideoId(youtubeUrl),
       'isProfilePrivate': user.isProfilePrivate,
@@ -53,8 +54,7 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .snapshots(),
         builder: (BuildContext context,
             AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> snapshot) {
@@ -78,10 +78,8 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
-            .where('userId',
-                isEqualTo: FirebaseFirestore.instance.doc('/users/${user.id}'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
+            .where('userId', isEqualTo: docRef('users', user.id!))
             .snapshots(),
         builder: (BuildContext context,
             AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> snapshot) {
@@ -104,8 +102,7 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .where('isProfilePrivate', isNotEqualTo: true)
             .snapshots(),
         builder: (BuildContext context,

--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/teachable_item_category.dart'; // For deleting items within a category
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class TeachableItemCategoryFunctions {
   static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -13,7 +14,7 @@ class TeachableItemCategoryFunctions {
   }) async {
     try {
       print('Adding category: $name to course: $courseId');
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       // Get highest sortOrder for the course
       QuerySnapshot<Map<String, dynamic>>? querySnapshot;
@@ -63,7 +64,7 @@ class TeachableItemCategoryFunctions {
     required String courseId,
     required List<String> names,
   }) async {
-    final courseRef = _firestore.collection('courses').doc(courseId);
+    final courseRef = docRef('courses', courseId);
     final batch = _firestore.batch();
     final collection = _firestore.collection(_collectionPath);
     final docRefs = <DocumentReference>[];
@@ -189,7 +190,7 @@ class TeachableItemCategoryFunctions {
 
   static Future<List<TeachableItemCategory>> getCategoriesForCourse(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final snapshot = await FirebaseFirestore.instance
           .collection(_collectionPath)

--- a/lib/data/data_helpers/teachable_item_functions.dart
+++ b/lib/data/data_helpers/teachable_item_functions.dart
@@ -17,9 +17,8 @@ class TeachableItemFunctions {
         TeachableItemInclusionStatus.excluded,
   }) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
-      final categoryRef =
-          _firestore.collection('teachableItemCategories').doc(categoryId);
+      final courseRef = docRef('courses', courseId);
+      final categoryRef = docRef('teachableItemCategories', categoryId);
 
       // Determine next sortOrder
       final querySnapshot = await _firestore
@@ -303,8 +302,7 @@ class TeachableItemFunctions {
 
   static Future<List<TeachableItem>> getItemsForCourse(String courseId) async {
     try {
-      final courseRef =
-          FirebaseFirestore.instance.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final snapshot = await FirebaseFirestore.instance
           .collection(_collectionPath)

--- a/lib/data/data_helpers/teachable_item_tag_functions.dart
+++ b/lib/data/data_helpers/teachable_item_tag_functions.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class TeachableItemTagFunctions {
   static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -12,7 +13,7 @@ class TeachableItemTagFunctions {
     required String color,
   }) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final docRef = await _firestore.collection(_collectionPath).add({
         'courseId': courseRef,
@@ -79,7 +80,7 @@ class TeachableItemTagFunctions {
 
   static Future<List<TeachableItemTag>> getTagsForCourse(String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final querySnapshot = await _firestore
           .collection(_collectionPath)

--- a/lib/data/data_helpers/user_functions.dart
+++ b/lib/data/data_helpers/user_functions.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:flutter/foundation.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:social_learning/data/course.dart';
@@ -57,7 +58,7 @@ class UserFunctions {
   }
 
   static void updateCurrentCourse(User currentUser, String courseId) async {
-    var courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
+    var courseRef = docRef('courses', courseId);
     currentUser.currentCourseId = courseRef;
     FirebaseFirestore.instance
         .collection('users')
@@ -167,7 +168,7 @@ class UserFunctions {
     // Update course proficiency.
     if (courseProficiency != null) {
       // Remove the old entry.
-      await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+      await docRef('users', user.id!).update({
         'courseProficiencies': FieldValue.arrayRemove([
           {
             'courseId': courseProficiency.courseId,
@@ -178,10 +179,10 @@ class UserFunctions {
     }
 
     // Add the new entry.
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id!).update({
       'courseProficiencies': FieldValue.arrayUnion([
         {
-          'courseId': FirebaseFirestore.instance.doc('/courses/${course.id}'),
+          'courseId': docRef('courses', course.id),
           'proficiency': proficiency,
         }
       ]),
@@ -191,9 +192,8 @@ class UserFunctions {
     if (courseProficiency != null) {
       courseProficiency.proficiency = proficiency;
     } else {
-      user.courseProficiencies?.add(CourseProficiency(
-          FirebaseFirestore.instance.doc('/courses/${course.id}'),
-          proficiency));
+      user.courseProficiencies?.add(
+          CourseProficiency(docRef('courses', course.id), proficiency));
     }
 
     print('Updated proficiency to $proficiency.');
@@ -209,7 +209,7 @@ class UserFunctions {
     profileText = profileText.trim();
     user.profileText = profileText;
 
-    FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    docRef('users', user.id!).update({
       'profileText': profileText,
     });
   }
@@ -227,7 +227,7 @@ class UserFunctions {
 
     removeGeoFromPracticeRecords(user);
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id!).update({
       'isGeoLocationEnabled': false,
       'location': null,
       'roughUserLocation': null,
@@ -268,7 +268,7 @@ class UserFunctions {
 
     user.isGeoLocationEnabled = true;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id!).update({
       'isGeoLocationEnabled': true,
     });
 
@@ -329,9 +329,7 @@ class UserFunctions {
       }
 
       user.location = newLocation;
-      await FirebaseFirestore.instance
-          .doc('/users/${applicationState.currentUser!.id}')
-          .update(userData);
+      await docRef('users', applicationState.currentUser!.id).update(userData);
 
       return true;
     } catch (e) {
@@ -373,8 +371,7 @@ class UserFunctions {
       WriteBatch batch = FirebaseFirestore.instance.batch();
       for (var doc in snapshot.docs) {
         var record = PracticeRecord.fromSnapshot(doc);
-        batch.update(
-            FirebaseFirestore.instance.doc('practiceRecords/${record.id}'), {
+        batch.update(docRef('practiceRecords', record.id), {
           'roughUserLocation': currentLocation,
         });
       }
@@ -424,8 +421,7 @@ class UserFunctions {
         // TODO: Perhaps batch the writes.
         var record = PracticeRecord.fromSnapshot(doc);
         if (record.roughUserLocation != null) {
-          batch.update(
-              FirebaseFirestore.instance.doc('practiceRecords/${record.id}'), {
+          batch.update(docRef('practiceRecords', record.id), {
             'roughUserLocation': null,
           });
         }
@@ -456,7 +452,7 @@ class UserFunctions {
 
     user.instagramHandle = newInstagramHandle;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id!).update({
       'instagramHandle': newInstagramHandle,
     });
   }
@@ -487,7 +483,7 @@ class UserFunctions {
 
     user.calendlyUrl = newCalendlyUrl;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id!).update({
       'calendlyUrl': newCalendlyUrl,
     });
   }

--- a/lib/data_support/level_migration.dart
+++ b/lib/data_support/level_migration.dart
@@ -3,6 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/Level.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 /// Migrates the db version where levels were a type of lesson to where it's
 /// a high level object.
@@ -98,7 +99,7 @@ class LevelMigration {
           print('Updating lesson to refer to level.');
           var lessonDocRef = db.collection('lessons').doc(lesson.id);
           transaction.update(lessonDocRef, {
-            'levelId': FirebaseFirestore.instance.doc('/levels/$lastLevelId')
+            'levelId': docRef('levels', lastLevelId)
           });
         }
         // }

--- a/lib/session_pairing/testing/organizer_session_state_mock.dart
+++ b/lib/session_pairing/testing/organizer_session_state_mock.dart
@@ -5,6 +5,7 @@ import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/session_participant.dart';
 import 'package:social_learning/state/organizer_session_state.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class OrganizerSessionStateMock extends OrganizerSessionState {
   final List<SessionParticipant> _sessionParticipants = [];
@@ -12,7 +13,7 @@ class OrganizerSessionStateMock extends OrganizerSessionState {
   final Map<SessionParticipant, List<Lesson>> _graduatedLessons = {};
   final _course = Course(
       '/courses/malta', 'Malta', 'u58', 'A beautiful island', false, null);
-  final _courseRef = FirebaseFirestore.instance.doc('/courses/malta');
+  final _courseRef = docRef('courses', 'malta');
 
   int _uniqueIdGenerator = 2;
 
@@ -64,8 +65,8 @@ class OrganizerSessionStateMock extends OrganizerSessionState {
         Timestamp(0, 0));
     _participantUsers.add(user);
 
-    var userRef = FirebaseFirestore.instance.doc('/users/${user.id}');
-    var sessionRef = FirebaseFirestore.instance.doc('/sessions/$_sessionId');
+    var userRef = docRef('users', user.id!);
+    var sessionRef = docRef('sessions', _sessionId);
     var participant = SessionParticipant(
         nextId,
         sessionRef,

--- a/lib/state/application_state.dart
+++ b/lib/state/application_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
@@ -130,7 +131,7 @@ class ApplicationState extends ChangeNotifier {
   enrollInPrivateCourse(Course course) async {
     var currentUser = this.currentUser!;
 
-    await FirebaseFirestore.instance.doc('/users/${currentUser.id}').update({
+    await docRef('users', currentUser.id).update({
       'enrolledCourseIds': FieldValue.arrayUnion([course.docRef])
     });
 
@@ -144,7 +145,7 @@ class ApplicationState extends ChangeNotifier {
   unenrollCourse(Course course) async {
     var currentUser = this.currentUser!;
 
-    FirebaseFirestore.instance.doc('/users/${currentUser.id}').update({
+    docRef('users', currentUser.id).update({
       'enrolledCourseIds': FieldValue.arrayRemove([course.docRef])
     });
 
@@ -193,7 +194,7 @@ class ApplicationState extends ChangeNotifier {
 
   void setIsProfilePrivate(
       bool isProfilePrivate, ApplicationState applicationState) {
-    FirebaseFirestore.instance.doc('/users/${currentUser?.id}').update({
+    docRef('users', currentUser!.id).update({
       'isProfilePrivate': isProfilePrivate,
     });
     currentUser!.isProfilePrivate = isProfilePrivate;
@@ -218,9 +219,7 @@ class ApplicationState extends ChangeNotifier {
   void _setProgressVideosPrivate(bool isProfilePrivate) {
     FirebaseFirestore.instance
         .collection('progressVideos')
-        .where('userId',
-            isEqualTo:
-                FirebaseFirestore.instance.doc('/users/${currentUser?.id}'))
+        .where('userId', isEqualTo: docRef('users', currentUser!.id))
         .get()
         .then((snapshot) {
       for (var doc in snapshot.docs) {

--- a/lib/state/firestore_subscription/session_participants_subscription.dart
+++ b/lib/state/firestore_subscription/session_participants_subscription.dart
@@ -3,6 +3,7 @@ import 'package:social_learning/data/session_participant.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/data_helpers/user_functions.dart';
 import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/state/firestore_subscription/firestore_list_subscription.dart';
 import 'package:social_learning/state/firestore_subscription/participant_users_subscription.dart';
 import 'package:social_learning/state/firestore_subscription/session_subscription.dart';
@@ -88,12 +89,10 @@ class SessionParticipantsSubscription
       // TODO: This seems to create entries too aggressively.
       print('Student added itself as a participant');
       FirebaseFirestore.instance.collection('sessionParticipants').add({
-        'sessionId': FirebaseFirestore.instance.doc('/sessions/${session.id}'),
-        'participantId':
-            FirebaseFirestore.instance.doc('/users/${currentUser?.id}'),
+        'sessionId': docRef('sessions', session.id),
+        'participantId': docRef('users', currentUser!.id),
         'participantUid': currentUser?.uid,
-        'courseId':
-            FirebaseFirestore.instance.doc('/courses/${session.courseId.id}'),
+        'courseId': docRef('courses', session.courseId.id),
         'isInstructor': currentUser?.isAdmin,
         'isActive': true,
         'teachCount': 0,

--- a/lib/state/organizer_session_state.dart
+++ b/lib/state/organizer_session_state.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/session.dart';
 import 'package:social_learning/data/session_pairing.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/session_participant.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/globals.dart';
@@ -142,7 +143,7 @@ class OrganizerSessionState extends ChangeNotifier {
         .instance
         .collection('sessions')
         .add(<String, dynamic>{
-      'courseId': FirebaseFirestore.instance.doc('/courses/${course.id}'),
+      'courseId': docRef('courses', course.id!),
       'name': sessionName,
       'organizerUid': organizer.uid,
       'organizerName': organizer.displayName,
@@ -158,10 +159,10 @@ class OrganizerSessionState extends ChangeNotifier {
         await FirebaseFirestore.instance
             .collection('sessionParticipants')
             .add(<String, dynamic>{
-      'sessionId': FirebaseFirestore.instance.doc('/sessions/$sessionId'),
-      'participantId': FirebaseFirestore.instance.doc('/users/${organizer.id}'),
+      'sessionId': docRef('sessions', sessionId),
+      'participantId': docRef('users', organizer.id!),
       'participantUid': organizer.uid,
-      'courseId': FirebaseFirestore.instance.doc('/courses/${course.id}'),
+      'courseId': docRef('courses', course.id!),
       'isInstructor': organizer.isAdmin,
       'isActive': true,
       'teachCount': 0,
@@ -183,12 +184,12 @@ class OrganizerSessionState extends ChangeNotifier {
     _sessionSubscription.resubscribe(() => '/sessions/$sessionId');
 
     _sessionParticipantsSubscription.resubscribe((collectionReference) =>
-        collectionReference.where('sessionId',
-            isEqualTo: FirebaseFirestore.instance.doc('/sessions/$sessionId')));
+        collectionReference.where(
+            'sessionId', isEqualTo: docRef('sessions', sessionId)));
 
     _sessionPairingSubscription.resubscribe((collectionReference) =>
-        collectionReference.where('sessionId',
-            isEqualTo: FirebaseFirestore.instance.doc('/sessions/$sessionId')));
+        collectionReference.where(
+            'sessionId', isEqualTo: docRef('sessions', sessionId)));
   }
 
   void saveNextRound(PairedSession pairedSession) {
@@ -203,15 +204,13 @@ class OrganizerSessionState extends ChangeNotifier {
       FirebaseFirestore.instance
           .collection('sessionPairings')
           .add(<String, dynamic>{
-        'sessionId':
-            FirebaseFirestore.instance.doc('/sessions/${currentSession?.id}'),
+        'sessionId': docRef('sessions', currentSession!.id!),
         'roundNumber': currentRound,
-        'mentorId': FirebaseFirestore.instance
-            .doc('/users/${pair.teachingParticipant.participantId.id}'),
-        'menteeId': FirebaseFirestore.instance
-            .doc('/users/${pair.learningParticipant.participantId.id}'),
-        'lessonId':
-            FirebaseFirestore.instance.doc('/lessons/${pair.lesson!.id}'),
+        'mentorId':
+            docRef('users', pair.teachingParticipant.participantId.id),
+        'menteeId':
+            docRef('users', pair.learningParticipant.participantId.id),
+        'lessonId': docRef('lessons', pair.lesson!.id!),
       }).catchError((error) {
         print('Failed to save session pairing: $error');
       });
@@ -247,9 +246,7 @@ class OrganizerSessionState extends ChangeNotifier {
 
   void endSession() {
     // Set the session to inactive.
-    FirebaseFirestore.instance
-        .doc('/sessions/${currentSession?.id}')
-        .update({'isActive': false});
+    docRef('sessions', currentSession!.id!).update({'isActive': false});
 
     _sessionSubscription.cancel();
     _sessionParticipantsSubscription.cancel();
@@ -301,8 +298,7 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void removeMentor(SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
       'mentorId': null,
     }).then((value) {
@@ -313,8 +309,7 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void removeMentee(SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
       'menteeId': null,
     }).then((value) {
@@ -325,10 +320,9 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void addMentor(User selectedUser, SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
-      'mentorId': FirebaseFirestore.instance.doc('/users/${selectedUser.id}'),
+      'mentorId': docRef('users', selectedUser.id!),
     }).then((value) {
       print('Added mentor to session pairing.');
     }).catchError((error) {
@@ -337,10 +331,9 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void addMentee(User selectedUser, SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
-      'menteeId': FirebaseFirestore.instance.doc('/users/${selectedUser.id}'),
+      'menteeId': docRef('users', selectedUser.id!),
     }).then((value) {
       print('Added mentee to session pairing.');
     }).catchError((error) {
@@ -353,8 +346,7 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void removeLesson(SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
       'lessonId': null,
     }).then((value) {
@@ -365,10 +357,9 @@ class OrganizerSessionState extends ChangeNotifier {
   }
 
   void addLesson(Lesson lesson, SessionPairing sessionPairing) {
-    FirebaseFirestore.instance
-        .doc('/sessionPairings/${sessionPairing.id}')
+    docRef('sessionPairings', sessionPairing.id!)
         .update({
-      'lessonId': FirebaseFirestore.instance.doc('/lessons/${lesson.id}'),
+      'lessonId': docRef('lessons', lesson.id!),
     }).then((value) {
       print('Added lesson to session pairing.');
     }).catchError((error) {

--- a/lib/state/student_session_state.dart
+++ b/lib/state/student_session_state.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/session_participant.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/firestore_subscription/participant_users_subscription.dart';
 import 'package:social_learning/state/firestore_subscription/session_pairings_subscription.dart';
@@ -91,7 +92,7 @@ class StudentSessionState extends ChangeNotifier {
     }
 
     print('Checking active session for user ${currentUser.id}');
-    var userIdRef = FirebaseFirestore.instance.doc('/users/${currentUser.id}');
+    var userIdRef = docRef('users', currentUser.id);
     FirebaseFirestore.instance
         .collection('sessionParticipants')
         .where('participantId', isEqualTo: userIdRef)
@@ -120,12 +121,12 @@ class StudentSessionState extends ChangeNotifier {
     _sessionSubscription.resubscribe(() => '/sessions/$sessionId');
 
     _sessionParticipantsSubscription.resubscribe((collectionReference) =>
-        collectionReference.where('sessionId',
-            isEqualTo: FirebaseFirestore.instance.doc('/sessions/$sessionId')));
+        collectionReference.where(
+            'sessionId', isEqualTo: docRef('sessions', sessionId)));
 
     _sessionPairingSubscription.resubscribe((collectionReference) =>
-        collectionReference.where('sessionId',
-            isEqualTo: FirebaseFirestore.instance.doc('/sessions/$sessionId')));
+        collectionReference.where(
+            'sessionId', isEqualTo: docRef('sessions', sessionId)));
 
     // TODO: Check if organizer and re-direct.
     // TODO: Add self as participant if needed.

--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
@@ -73,8 +74,7 @@ class CmsLessonState extends State<CmsLessonPage> {
     if (argument != null) {
       String? levelId = argument.levelId;
       if (levelId != null) {
-        _levelDocRef =
-            FirebaseFirestore.instance.collection('levels').doc(levelId);
+        _levelDocRef = docRef('levels', levelId);
       }
 
       String? lessonId = argument.lessonId;

--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_tag_functions.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/data/teachable_item_category.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
@@ -353,7 +354,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage>
       names: categoryNames,
     );
 
-    final courseRef = FirebaseFirestore.instance.collection('courses').doc(_courseId);
+    final courseRef = docRef('courses', _courseId!);
     final items = <TeachableItem>[];
     for (int i = 0; i < newCategories.length; i++) {
       final cat = newCategories[i];

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
@@ -10,6 +10,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inv
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/tag_pill.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class InventoryItemEntry extends InventoryEntry {
   TeachableItem item;
@@ -178,6 +179,5 @@ class InventoryItemEntry extends InventoryEntry {
     }
   }
 
-  String _getRefPath(TeachableItemTag tag) =>
-      FirebaseFirestore.instance.collection('teachableItemTags').doc(tag.id).path;
+  String _getRefPath(TeachableItemTag tag) => docRef('teachableItemTags', tag.id!).path;
 }

--- a/lib/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart
+++ b/lib/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
 import 'package:social_learning/data/user.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
 
@@ -81,7 +82,7 @@ class ProfileImageByUserIdWidgetState
   }
 
   Future<void> init() async {
-    var userRef = FirebaseFirestore.instance.doc('/users/${widget.userId.id}');
+    var userRef = docRef('users', widget.userId.id);
     // TODO: Add caching!
     DocumentSnapshot<Map<String, dynamic>> userSnapshot = await userRef.get();
 

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/Level.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -450,8 +451,7 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   Widget _createCommentsView(Lesson lesson, BuildContext context,
       LibraryState libraryState, ApplicationState applicationState) {
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
+    DocumentReference lessonId = docRef('lessons', lesson.id!);
     print('Querying for comments for lesson: $lessonId');
     Widget commentColumn = StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
@@ -784,8 +784,7 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   _createConnectView(BuildContext context, Lesson lesson,
       ApplicationState applicationState, LibraryState libraryState) {
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
+    DocumentReference lessonId = docRef('lessons', lesson.id!);
     User? currentUser = applicationState.currentUser;
     GeoPoint? currentLocation = currentUser?.location;
 


### PR DESCRIPTION
## Summary
- add `reference_helper` import to many files
- use `docRef` helper instead of `FirebaseFirestore.instance.doc` or `collection().doc` calls
- update unit files and mocks accordingly

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d42844c4c832e9994cfa849236c21