### PR TITLE
Refactor to use docRef

### DIFF
--- a/lib/data/data_helpers/course_profile_functions.dart
+++ b/lib/data/data_helpers/course_profile_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/course_profile.dart';
 
 class CourseProfileFunctions {
@@ -7,7 +8,7 @@ class CourseProfileFunctions {
 
   static Future<CourseProfile?> getCourseProfile(String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final querySnapshot = await _firestore
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)
@@ -38,7 +39,7 @@ class CourseProfileFunctions {
         };
         dataToUpdate.remove('createdAt');
 
-        await _firestore.collection(_collectionPath).doc(profile.id).update(dataToUpdate);
+        await docRef(_collectionPath, profile.id).update(dataToUpdate);
         print('Course profile updated successfully.');
       } else {
         // Create new

--- a/lib/data/data_helpers/learning_objective_functions.dart
+++ b/lib/data/data_helpers/learning_objective_functions.dart
@@ -9,7 +9,7 @@ class LearningObjectiveFunctions {
   static Future<List<LearningObjective>> getObjectivesForCourse(
       String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final snapshot = await _firestore
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)
@@ -34,7 +34,7 @@ class LearningObjectiveFunctions {
     print(
         'LearningObjectiveFunctions: Saving objective: $id, courseId: $courseId, sortOrder: $sortOrder, name: $name, description: $description, teachableItemIds: $teachableItemIds');
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
       final data = {
         'courseId': courseRef,
         'sortOrder': sortOrder,
@@ -49,9 +49,8 @@ class LearningObjectiveFunctions {
         final snapshot = await docRef.get();
         return LearningObjective.fromSnapshot(snapshot);
       } else {
-        await _firestore.collection(_collectionPath).doc(id).update(data);
-        final snapshot =
-            await _firestore.collection(_collectionPath).doc(id).get();
+        await docRef(_collectionPath, id).update(data);
+        final snapshot = await docRef(_collectionPath, id).get();
         return LearningObjective.fromSnapshot(snapshot);
       }
     } catch (e) {
@@ -65,7 +64,7 @@ class LearningObjectiveFunctions {
     required DocumentReference teachableItemRef,
   }) async {
     try {
-      await _firestore.collection(_collectionPath).doc(objectiveId).update({
+      await docRef(_collectionPath, objectiveId).update({
         'teachableItemIds': FieldValue.arrayUnion([teachableItemRef]),
         'modifiedAt': FieldValue.serverTimestamp(),
       });
@@ -79,7 +78,7 @@ class LearningObjectiveFunctions {
     required DocumentReference teachableItemRef,
   }) async {
     try {
-      await _firestore.collection(_collectionPath).doc(objectiveId).update({
+      await docRef(_collectionPath, objectiveId).update({
         'teachableItemIds': FieldValue.arrayRemove([teachableItemRef]),
         'modifiedAt': FieldValue.serverTimestamp(),
       });
@@ -90,7 +89,7 @@ class LearningObjectiveFunctions {
 
   static deleteObjective(LearningObjective objective) async {
     try {
-      await _firestore.collection(_collectionPath).doc(objective.id).delete();
+      await docRef(_collectionPath, objective.id).delete();
     } catch (e) {
       print('Error deleting objective ${objective.id}: $e');
     }
@@ -101,7 +100,7 @@ class LearningObjectiveFunctions {
     name = name.trim();
     description = description?.trim();
 
-    var docRef = _firestore.collection(_collectionPath).doc(id);
+    var docRef = docRef(_collectionPath, id);
     await docRef.update({
         'name': name,
         'description': description,
@@ -117,7 +116,7 @@ class LearningObjectiveFunctions {
     print(
         'Adding objective: courseId: $courseId, name: $name, sortOrder: $sortOrder');
     name = name.trim();
-    final courseRef = _firestore.collection('courses').doc(courseId);
+    final courseRef = docRef('courses', courseId);
     var docRef = await _firestore.collection(_collectionPath).add({
       'courseId': courseRef,
       'sortOrder': sortOrder,

--- a/lib/data/data_helpers/progress_video_functions.dart
+++ b/lib/data/data_helpers/progress_video_functions.dart
@@ -1,5 +1,6 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -33,11 +34,11 @@ class ProgressVideoFunctions {
     await FirebaseFirestore.instance
         .collection('progressVideos')
         .add(<String, dynamic>{
-      'userId': FirebaseFirestore.instance.doc('/users/${user.id}'),
+      'userId': docRef('users', user.id),
       'userUid': user.uid,
       'courseId':
-          FirebaseFirestore.instance.doc('/courses/${lesson.courseId.id}'),
-      'lessonId': FirebaseFirestore.instance.doc('/lessons/${lesson.id}'),
+          docRef('courses', lesson.courseId.id),
+      'lessonId': docRef('lessons', lesson.id),
       'youtubeUrl': youtubeUrl,
       'youtubeVideoId': extractYouTubeVideoId(youtubeUrl),
       'isProfilePrivate': user.isProfilePrivate,
@@ -53,8 +54,7 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .snapshots(),
         builder: (BuildContext context,
             AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> snapshot) {
@@ -78,10 +78,8 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
-            .where('userId',
-                isEqualTo: FirebaseFirestore.instance.doc('/users/${user.id}'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
+            .where('userId', isEqualTo: docRef('users', user.id))
             .snapshots(),
         builder: (BuildContext context,
             AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>> snapshot) {
@@ -104,8 +102,7 @@ class ProgressVideoFunctions {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
             .collection('progressVideos')
-            .where('lessonId',
-                isEqualTo: FirebaseFirestore.instance.doc('/lessons/$lessonId'))
+            .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .where('isProfilePrivate', isNotEqualTo: true)
             .snapshots(),
         builder: (BuildContext context,
@@ -165,10 +162,10 @@ class ProgressVideoFunctions {
       Widget Function(
               BuildContext context, List<List<ProgressVideo>> progressVideos)
           builder) {
-    var currentUserRef = FirebaseFirestore.instance
-        .doc('/users/${applicationState.currentUser?.id}');
-    var currentDocRef = FirebaseFirestore.instance
-        .doc('/courses/${libraryState.selectedCourse?.id}');
+    var currentUserRef =
+        docRef('users', applicationState.currentUser?.id ?? '');
+    var currentDocRef =
+        docRef('courses', libraryState.selectedCourse?.id ?? '');
 
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
@@ -206,10 +203,9 @@ class ProgressVideoFunctions {
   static Future<List<List<ProgressVideo>>> createProfileProgressVideoFuture(
       User user,
       LibraryState libraryState) async {
-    var currentUserRef = FirebaseFirestore.instance
-        .doc('/users/${user.id}');
-    var currentDocRef = FirebaseFirestore.instance
-        .doc('/courses/${libraryState.selectedCourse?.id}');
+    var currentUserRef = docRef('users', user.id);
+    var currentDocRef =
+        docRef('courses', libraryState.selectedCourse?.id ?? '');
 
     QuerySnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
         .instance

--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/teachable_item_category.dart'; // For deleting items within a category
 
@@ -13,7 +14,7 @@ class TeachableItemCategoryFunctions {
   }) async {
     try {
       print('Adding category: $name to course: $courseId');
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       // Get highest sortOrder for the course
       QuerySnapshot<Map<String, dynamic>>? querySnapshot;
@@ -63,7 +64,7 @@ class TeachableItemCategoryFunctions {
     required String courseId,
     required List<String> names,
   }) async {
-    final courseRef = _firestore.collection('courses').doc(courseId);
+    final courseRef = docRef('courses', courseId);
     final batch = _firestore.batch();
     final collection = _firestore.collection(_collectionPath);
     final docRefs = <DocumentReference>[];
@@ -91,7 +92,7 @@ class TeachableItemCategoryFunctions {
     // Description is not part of the model, so not included here.
   }) async {
     try {
-      await _firestore.collection(_collectionPath).doc(categoryId).update({
+      await docRef(_collectionPath, categoryId).update({
         'name': name,
         'modifiedAt': FieldValue.serverTimestamp(),
       });
@@ -105,7 +106,7 @@ class TeachableItemCategoryFunctions {
     required String categoryId,
   }) async {
     try {
-      final categoryRef = _firestore.collection(_collectionPath).doc(categoryId);
+      final categoryRef = docRef(_collectionPath, categoryId);
       final categorySnapshot = await categoryRef.get();
       if (!categorySnapshot.exists) {
         print('Category $categoryId not found for deletion.');
@@ -173,7 +174,7 @@ class TeachableItemCategoryFunctions {
       for (int i = 0; i < sorted.length; i++) {
         final category = sorted[i];
         if (category.sortOrder != i) {
-          final ref = _firestore.collection(_collectionPath).doc(category.id);
+          final ref = docRef(_collectionPath, category.id);
           batch.update(ref, {
             'sortOrder': i,
             'modifiedAt': FieldValue.serverTimestamp(),
@@ -189,7 +190,7 @@ class TeachableItemCategoryFunctions {
 
   static Future<List<TeachableItemCategory>> getCategoriesForCourse(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final snapshot = await FirebaseFirestore.instance
           .collection(_collectionPath)

--- a/lib/data/data_helpers/teachable_item_tag_functions.dart
+++ b/lib/data/data_helpers/teachable_item_tag_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
 
 class TeachableItemTagFunctions {
@@ -12,7 +13,7 @@ class TeachableItemTagFunctions {
     required String color,
   }) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final docRef = await _firestore.collection(_collectionPath).add({
         'courseId': courseRef,
@@ -37,7 +38,7 @@ class TeachableItemTagFunctions {
     required String color,
   }) async {
     try {
-      await _firestore.collection(_collectionPath).doc(tagId).update({
+      await docRef(_collectionPath, tagId).update({
         'name': name,
         'color': color,
         'modifiedAt': FieldValue.serverTimestamp(),
@@ -51,7 +52,7 @@ class TeachableItemTagFunctions {
     required String tagId,
   }) async {
     try {
-      final tagRef = _firestore.collection(_collectionPath).doc(tagId);
+      final tagRef = docRef(_collectionPath, tagId);
       WriteBatch batch = _firestore.batch();
 
       // 1. Find all TeachableItems that reference this tag
@@ -79,7 +80,7 @@ class TeachableItemTagFunctions {
 
   static Future<List<TeachableItemTag>> getTagsForCourse(String courseId) async {
     try {
-      final courseRef = _firestore.collection('courses').doc(courseId);
+      final courseRef = docRef('courses', courseId);
 
       final querySnapshot = await _firestore
           .collection(_collectionPath)

--- a/lib/data/data_helpers/user_functions.dart
+++ b/lib/data/data_helpers/user_functions.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
@@ -57,7 +58,7 @@ class UserFunctions {
   }
 
   static void updateCurrentCourse(User currentUser, String courseId) async {
-    var courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
+    var courseRef = docRef('courses', courseId);
     currentUser.currentCourseId = courseRef;
     FirebaseFirestore.instance
         .collection('users')
@@ -167,7 +168,7 @@ class UserFunctions {
     // Update course proficiency.
     if (courseProficiency != null) {
       // Remove the old entry.
-      await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+      await docRef('users', user.id).update({
         'courseProficiencies': FieldValue.arrayRemove([
           {
             'courseId': courseProficiency.courseId,
@@ -178,10 +179,10 @@ class UserFunctions {
     }
 
     // Add the new entry.
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id).update({
       'courseProficiencies': FieldValue.arrayUnion([
         {
-          'courseId': FirebaseFirestore.instance.doc('/courses/${course.id}'),
+          'courseId': docRef('courses', course.id),
           'proficiency': proficiency,
         }
       ]),
@@ -192,7 +193,7 @@ class UserFunctions {
       courseProficiency.proficiency = proficiency;
     } else {
       user.courseProficiencies?.add(CourseProficiency(
-          FirebaseFirestore.instance.doc('/courses/${course.id}'),
+          docRef('courses', course.id),
           proficiency));
     }
 
@@ -209,7 +210,7 @@ class UserFunctions {
     profileText = profileText.trim();
     user.profileText = profileText;
 
-    FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    docRef('users', user.id).update({
       'profileText': profileText,
     });
   }
@@ -227,7 +228,7 @@ class UserFunctions {
 
     removeGeoFromPracticeRecords(user);
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id).update({
       'isGeoLocationEnabled': false,
       'location': null,
       'roughUserLocation': null,
@@ -268,7 +269,7 @@ class UserFunctions {
 
     user.isGeoLocationEnabled = true;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id).update({
       'isGeoLocationEnabled': true,
     });
 
@@ -329,8 +330,7 @@ class UserFunctions {
       }
 
       user.location = newLocation;
-      await FirebaseFirestore.instance
-          .doc('/users/${applicationState.currentUser!.id}')
+      await docRef('users', applicationState.currentUser!.id)
           .update(userData);
 
       return true;
@@ -374,7 +374,7 @@ class UserFunctions {
       for (var doc in snapshot.docs) {
         var record = PracticeRecord.fromSnapshot(doc);
         batch.update(
-            FirebaseFirestore.instance.doc('practiceRecords/${record.id}'), {
+            docRef('practiceRecords', record.id), {
           'roughUserLocation': currentLocation,
         });
       }
@@ -425,7 +425,7 @@ class UserFunctions {
         var record = PracticeRecord.fromSnapshot(doc);
         if (record.roughUserLocation != null) {
           batch.update(
-              FirebaseFirestore.instance.doc('practiceRecords/${record.id}'), {
+              docRef('practiceRecords', record.id), {
             'roughUserLocation': null,
           });
         }
@@ -456,7 +456,7 @@ class UserFunctions {
 
     user.instagramHandle = newInstagramHandle;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id).update({
       'instagramHandle': newInstagramHandle,
     });
   }
@@ -487,7 +487,7 @@ class UserFunctions {
 
     user.calendlyUrl = newCalendlyUrl;
 
-    await FirebaseFirestore.instance.doc('/users/${user.id}').update({
+    await docRef('users', user.id).update({
       'calendlyUrl': newCalendlyUrl,
     });
   }

--- a/lib/data/lesson.dart
+++ b/lib/data/lesson.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class Lesson {
   String? id;
@@ -76,9 +77,8 @@ class Lesson {
 
   Lesson.fromJson(Map<String, dynamic> json, String fullLevelId)
       : id = json['id'],
-        courseId = FirebaseFirestore.instance.doc(json['courseId']),
-        levelId =
-            FirebaseFirestore.instance.doc(json['levelId'] ?? fullLevelId),
+        courseId = docRef('courses', json['courseId']),
+        levelId = docRef('levels', json['levelId'] ?? fullLevelId),
         sortOrder = -1,
         title = json['title'],
         synopsis = json['synopsis'],

--- a/lib/data/online_session.dart
+++ b/lib/data/online_session.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 enum OnlineSessionStatus {
   waiting, // 0
@@ -95,7 +96,7 @@ class OnlineSession {
 
   OnlineSession.fromJson(Map<String, dynamic> json)
       : id = json['id'] as String?,
-        courseId = FirebaseFirestore.instance.doc(json['courseId'] as String),
+        courseId = docRef('courses', json['courseId'] as String),
         learnerUid = json['learnerUid'] as String?,
         mentorUid = json['mentorUid'] as String?,
         videoCallUrl = json['videoCallUrl'] as String?,

--- a/lib/session_pairing/testing/organizer_session_state_mock.dart
+++ b/lib/session_pairing/testing/organizer_session_state_mock.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/learning_strategy_enum.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -12,7 +13,7 @@ class OrganizerSessionStateMock extends OrganizerSessionState {
   final Map<SessionParticipant, List<Lesson>> _graduatedLessons = {};
   final _course = Course(
       '/courses/malta', 'Malta', 'u58', 'A beautiful island', false, null);
-  final _courseRef = FirebaseFirestore.instance.doc('/courses/malta');
+  final _courseRef = docRef('courses', 'malta');
 
   int _uniqueIdGenerator = 2;
 
@@ -64,8 +65,8 @@ class OrganizerSessionStateMock extends OrganizerSessionState {
         Timestamp(0, 0));
     _participantUsers.add(user);
 
-    var userRef = FirebaseFirestore.instance.doc('/users/${user.id}');
-    var sessionRef = FirebaseFirestore.instance.doc('/sessions/$_sessionId');
+    var userRef = docRef('users', user.id);
+    var sessionRef = docRef('sessions', _sessionId);
     var participant = SessionParticipant(
         nextId,
         sessionRef,

--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -73,8 +74,7 @@ class CmsLessonState extends State<CmsLessonPage> {
     if (argument != null) {
       String? levelId = argument.levelId;
       if (levelId != null) {
-        _levelDocRef =
-            FirebaseFirestore.instance.collection('levels').doc(levelId);
+        _levelDocRef = docRef('levels', levelId);
       }
 
       String? lessonId = argument.lessonId;

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_data_context.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_data_context.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/cloud_functions/cloud_functions.dart';
 import 'package:social_learning/cloud_functions/inventory_generation_response.dart';
 import 'package:social_learning/data/course.dart';
@@ -81,13 +82,11 @@ class InventoryDataContext implements InventoryContext {
       names: categoryNames,
     );
 
-    final courseRef = FirebaseFirestore.instance.collection('courses').doc(courseId);
+    final courseRef = docRef('courses', courseId);
     final items = <TeachableItem>[];
     for (int i = 0; i < newCategories.length; i++) {
       final cat = newCategories[i];
-      final catRef = FirebaseFirestore.instance
-          .collection('teachableItemCategories')
-          .doc(cat.id);
+      final catRef = docRef('teachableItemCategories', cat.id);
       final names = generated[i].items;
       for (int j = 0; j < names.length; j++) {
         items.add(

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/teachable_item.dart';
@@ -95,25 +96,19 @@ class InventoryDragHelper {
 
       newIndexInCategory = itemsInCategory.indexWhere((i) => i.id == target.item.id);
     } else if (target is AddNewItemEntry) {
-      newCategoryRef = FirebaseFirestore.instance
-          .collection('teachableItemCategories')
-          .doc(target.category.id);
+      newCategoryRef = docRef('teachableItemCategories', target.category.id);
 
       final itemsInCategory = context.getItemsForCategory(target.category.id!);
       newIndexInCategory = itemsInCategory.length;
     } else if (target is InventoryCategoryEntry) {
-      newCategoryRef = FirebaseFirestore.instance
-          .collection('teachableItemCategories')
-          .doc(target.category.id);
+      newCategoryRef = docRef('teachableItemCategories', target.category.id);
       newIndexInCategory = 0;
     } else if (target is AddNewCategoryEntry) {
       final lastCategory = (context.getCategories()
         ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder)))
           .last;
 
-      newCategoryRef = FirebaseFirestore.instance
-          .collection('teachableItemCategories')
-          .doc(lastCategory.id);
+      newCategoryRef = docRef('teachableItemCategories', lastCategory.id);
 
       final itemsInCategory = context.getItemsForCategory(lastCategory.id!);
       newIndexInCategory = itemsInCategory.length;

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/teachable_item.dart';
@@ -94,9 +95,7 @@ class InventoryItemEntry extends InventoryEntry {
                 'Remove tag?',
                 'Do you want to remove the tag "${tag.name}"?',
                     () async {
-                  final tagRef = FirebaseFirestore.instance
-                      .collection('teachableItemTags')
-                      .doc(tag.id);
+                  final tagRef = docRef('teachableItemTags', tag.id);
                   await TeachableItemFunctions.removeItemTagFromItem(
                     itemId: item.id!,
                     tagRef: tagRef,
@@ -127,9 +126,7 @@ class InventoryItemEntry extends InventoryEntry {
             TagFanoutWidget(
               availableTags: availableTags,
               onTagSelected: (tag) async {
-                final tagRef = FirebaseFirestore.instance
-                    .collection('teachableItemTags')
-                    .doc(tag.id);
+                final tagRef = docRef('teachableItemTags', tag.id);
 
                 await TeachableItemFunctions.assignTagToItem(
                   itemId: item.id!,
@@ -179,5 +176,5 @@ class InventoryItemEntry extends InventoryEntry {
   }
 
   String _getRefPath(TeachableItemTag tag) =>
-      FirebaseFirestore.instance.collection('teachableItemTags').doc(tag.id).path;
+      docRef('teachableItemTags', tag.id).path;
 }

--- a/lib/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart
+++ b/lib/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:social_learning/data/course.dart';
@@ -81,7 +82,7 @@ class ProfileImageByUserIdWidgetState
   }
 
   Future<void> init() async {
-    var userRef = FirebaseFirestore.instance.doc('/users/${widget.userId.id}');
+    var userRef = docRef('users', widget.userId.id);
     // TODO: Add caching!
     DocumentSnapshot<Map<String, dynamic>> userSnapshot = await userRef.get();
 

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -450,8 +451,7 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   Widget _createCommentsView(Lesson lesson, BuildContext context,
       LibraryState libraryState, ApplicationState applicationState) {
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
+    DocumentReference lessonId = docRef('lessons', lesson.id);
     print('Querying for comments for lesson: $lessonId');
     Widget commentColumn = StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
         stream: FirebaseFirestore.instance
@@ -784,8 +784,7 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   _createConnectView(BuildContext context, Lesson lesson,
       ApplicationState applicationState, LibraryState libraryState) {
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
+    DocumentReference lessonId = docRef('lessons', lesson.id);
     User? currentUser = applicationState.currentUser;
     GeoPoint? currentLocation = currentUser?.location;
 

--- a/lib/ui_foundation/other_profile_page.dart
+++ b/lib/ui_foundation/other_profile_page.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -55,8 +56,7 @@ class OtherProfileState extends State<OtherProfilePage> {
 
     String? otherUserId = _otherUserId;
     if (otherUserId != null) {
-      FirebaseFirestore.instance
-          .doc('users/$_otherUserId')
+      docRef('users', _otherUserId!)
           .get()
           .then((DocumentSnapshot<Map<String, dynamic>> snapshot) {
         if (snapshot.exists) {

--- a/lib/ui_foundation/profile_comparison_page.dart
+++ b/lib/ui_foundation/profile_comparison_page.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -52,8 +53,7 @@ class ProfileComparisonState extends State<ProfileComparisonPage> {
     String? otherUserId = _otherUserId;
     if (otherUserId != null) {
       // Load the other user info.
-      FirebaseFirestore.instance
-          .doc('users/$otherUserId')
+      docRef('users', otherUserId)
           .get()
           .then((DocumentSnapshot<Map<String, dynamic>> snapshot) {
         if (snapshot.exists) {


### PR DESCRIPTION
## Summary
- use `docRef` helper across modules to create Firestore document references
- simplify Firestore reference creation in state mocks, widgets, and data helpers

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d480ac2f4832ea35b706576c7ea0b