### PR TITLE
Fix snapshot generics

### DIFF
--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -67,7 +67,7 @@ class TeachableItemCategoryFunctions {
     final courseRef = docRef('courses', courseId);
     final batch = _firestore.batch();
     final collection = _firestore.collection(_collectionPath);
-    final docRefs = <DocumentReference>[];
+    final docRefs = <DocumentReference<Map<String, dynamic>>>[];
     for (int i = 0; i < names.length; i++) {
       final docRef = collection.doc();
       docRefs.add(docRef);

--- a/lib/data/data_helpers/teachable_item_functions.dart
+++ b/lib/data/data_helpers/teachable_item_functions.dart
@@ -63,7 +63,7 @@ class TeachableItemFunctions {
   static Future<List<TeachableItem>> bulkCreateItems(List<TeachableItem> items) async {
     final batch = _firestore.batch();
     final collection = _firestore.collection(_collectionPath);
-    final docRefs = <DocumentReference>[];
+    final docRefs = <DocumentReference<Map<String, dynamic>>>[];
     for (final item in items) {
       final docRef = collection.doc();
       docRefs.add(docRef);


### PR DESCRIPTION
## Summary
- fix generics in bulk create helpers to return `DocumentSnapshot<Map<String, dynamic>>`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d50267268832e9c91888c7dbb0e01