### PR TITLE
Fix concurrent loadInventoryData

### DIFF
--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -51,8 +51,8 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
     }
   }
 
-  Future<void> _loadContext(String courseId, Course? course) async {
-    final ctx = await InventoryDataContext.create(
+  void _loadContext(String courseId, Course? course) {
+    final ctx = InventoryDataContext.create(
       courseId: courseId,
       course: course,
       refresh: () => setState(() {}),
@@ -108,7 +108,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
                         oldIndex: oldIndex,
                         newIndex: newIndex,
                       );
-                      await dataContext.loadInventoryData();
+                      dataContext.loadInventoryData();
                     },
                     itemBuilder: (context, index) {
                       final entry = dataContext.inventoryEntries[index];


### PR DESCRIPTION
## Summary
- prevent concurrent loads in `InventoryDataContext`
- make context creation start loading in background
- stop awaiting on `loadInventoryData()`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d4b5d0e08832ea0b0b49b8f22f1f2