### PR TITLE
Add testable FirestoreService wrapper

### DIFF
--- a/lib/data/data_helpers/reference_helper.dart
+++ b/lib/data/data_helpers/reference_helper.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 DocumentReference<Map<String, dynamic>> docRef(
         String collectionName, String docId) =>
-    FirebaseFirestore.instance.doc('/$collectionName/$docId');
+    FirestoreService.instance.doc('/$collectionName/$docId');

--- a/lib/data/data_helpers/user_functions.dart
+++ b/lib/data/data_helpers/user_functions.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:flutter/foundation.dart';
@@ -15,7 +16,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 class UserFunctions {
   static void createUser(String uid, String? displayName, String? email) {
-    FirebaseFirestore.instance.collection('users').add(<String, dynamic>{
+    FirestoreService.instance.collection('users').add(<String, dynamic>{
       'uid': auth.FirebaseAuth.instance.currentUser!.uid,
       'displayName': displayName,
       'sortName': displayName?.toLowerCase(),
@@ -28,11 +29,11 @@ class UserFunctions {
   }
 
   static void updateDisplayName(String uid, String displayName) async {
-    var querySnapshot = await FirebaseFirestore.instance
+    var querySnapshot = await FirestoreService.instance
         .collection('users')
         .where('uid', isEqualTo: uid)
         .get();
-    FirebaseFirestore.instance
+    FirestoreService.instance
         .collection('users')
         .doc(querySnapshot.docs[0].id)
         .update({
@@ -44,11 +45,11 @@ class UserFunctions {
 
   static void updateProfilePhoto(String profileFireStoragePath) async {
     String uid = auth.FirebaseAuth.instance.currentUser!.uid;
-    var querySnapshot = await FirebaseFirestore.instance
+    var querySnapshot = await FirestoreService.instance
         .collection('users')
         .where('uid', isEqualTo: uid)
         .get();
-    FirebaseFirestore.instance
+    FirestoreService.instance
         .collection('users')
         .doc(querySnapshot.docs[0].id)
         .update({
@@ -60,7 +61,7 @@ class UserFunctions {
   static void updateCurrentCourse(User currentUser, String courseId) async {
     var courseRef = docRef('courses', courseId);
     currentUser.currentCourseId = courseRef;
-    FirebaseFirestore.instance
+    FirestoreService.instance
         .collection('users')
         .doc(currentUser.id)
         .set({'currentCourseId': courseRef}, SetOptions(merge: true));
@@ -80,7 +81,7 @@ class UserFunctions {
         String.fromCharCode(
             partialDisplayName.codeUnits[partialDisplayName.length - 1] + 1);
 
-    var snapshot = await FirebaseFirestore.instance
+    var snapshot = await FirestoreService.instance
         .collection('users')
         .where('sortName', isGreaterThanOrEqualTo: minStr)
         .where('sortName', isLessThan: maxStr)
@@ -95,7 +96,7 @@ class UserFunctions {
 
   static Future<User> getCurrentUser() async {
     String uid = auth.FirebaseAuth.instance.currentUser!.uid;
-    var snapshot = await FirebaseFirestore.instance
+    var snapshot = await FirestoreService.instance
         .collection('users')
         .where('uid', isEqualTo: uid)
         .get();
@@ -104,7 +105,7 @@ class UserFunctions {
   }
 
   static Future<User> getUserByUid(String uid) async {
-    var snapshot = await FirebaseFirestore.instance
+    var snapshot = await FirestoreService.instance
         .collection('users')
         .where('uid', isEqualTo: uid)
         .get();
@@ -113,7 +114,7 @@ class UserFunctions {
   }
 
   static Future<User> getUserById(String id) async {
-    var doc = await FirebaseFirestore.instance
+    var doc = await FirestoreService.instance
         .collection('users')
         .doc(id)
         .get();
@@ -363,14 +364,14 @@ class UserFunctions {
     }
 
     // Update the practice records.
-    FirebaseFirestore.instance
+    FirestoreService.instance
         .collection('practiceRecords')
         .where('menteeUid', isEqualTo: applicationState.currentUser!.uid)
         .where('isGraduation', isEqualTo: true)
         .get()
         .then((snapshot) {
       // TODO: Perhaps batch the writes.
-      WriteBatch batch = FirebaseFirestore.instance.batch();
+      WriteBatch batch = FirestoreService.instance.batch();
       for (var doc in snapshot.docs) {
         var record = PracticeRecord.fromSnapshot(doc);
         batch.update(
@@ -413,13 +414,13 @@ class UserFunctions {
   }
 
   static void removeGeoFromPracticeRecords(User user) {
-    FirebaseFirestore.instance
+    FirestoreService.instance
         .collection('practiceRecords')
         .where('menteeUid', isEqualTo: user.uid)
         .where('isGraduation', isEqualTo: true)
         .get()
         .then((snapshot) {
-      WriteBatch batch = FirebaseFirestore.instance.batch();
+      WriteBatch batch = FirestoreService.instance.batch();
       for (var doc in snapshot.docs) {
         // TODO: Perhaps batch the writes.
         var record = PracticeRecord.fromSnapshot(doc);

--- a/lib/data/firestore_service.dart
+++ b/lib/data/firestore_service.dart
@@ -1,0 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Singleton wrapper for [FirebaseFirestore] that allows overriding the
+/// instance in tests.
+class FirestoreService {
+  /// The Firestore instance used by the app. Tests can replace this
+  /// with a [FakeFirebaseFirestore].
+  static FirebaseFirestore instance = FirebaseFirestore.instance;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  fake_cloud_firestore: ^2.4.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/user_functions_test.dart
+++ b/test/user_functions_test.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/user.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() async {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+    await fake.collection('users').doc('u1').set({
+      'uid': 'uid1',
+      'displayName': 'Alice',
+      'sortName': 'alice',
+      'profileText': '',
+      'isAdmin': false,
+      'isProfilePrivate': false,
+      'isGeoLocationEnabled': false,
+      'created': Timestamp.now(),
+      'email': 'alice@example.com',
+    });
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('getUserById retrieves the user document', () async {
+    final user = await UserFunctions.getUserById('u1');
+    expect(user.uid, 'uid1');
+    expect(user.displayName, 'Alice');
+  });
+
+  test('getUserByUid queries by uid', () async {
+    final user = await UserFunctions.getUserByUid('uid1');
+    expect(user.id, 'u1');
+  });
+
+  test('updateCurrentCourse writes reference', () async {
+    final snap = await fake.collection('users').doc('u1').get();
+    final user = User.fromSnapshot(snap);
+
+    await UserFunctions.updateCurrentCourse(user, 'course1');
+
+    final updated = await fake.collection('users').doc('u1').get();
+    final ref = updated.data()?['currentCourseId'] as DocumentReference;
+    expect(ref.path, '/courses/course1');
+  });
+}


### PR DESCRIPTION
## Summary
- add `FirestoreService` singleton to allow swapping `FirebaseFirestore`
- update `reference_helper` and `UserFunctions` to use the new service
- add `fake_cloud_firestore` as a dev dependency
- create unit tests for `UserFunctions` using `FakeFirebaseFirestore`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d54d04790832e92bb8b807467752e