### PR TITLE
Enable Firestore injection for tests

### DIFF
--- a/lib/data/Level.dart
+++ b/lib/data/Level.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class Level {
   String? id;
@@ -29,7 +30,7 @@ class Level {
 
   Level.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        courseId = FirebaseFirestore.instance.doc(json['courseId']),
+        courseId = FirestoreService.instance.doc(json['courseId']),
         title = json['title'] as String,
         description = json['description'] as String,
         sortOrder = -1,

--- a/lib/data/course.dart
+++ b/lib/data/course.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class Course {
   String? id;
@@ -28,5 +29,5 @@ class Course {
         invitationCode = doc.data()?['invitationCode'] as String?;
 
   DocumentReference get docRef =>
-      FirebaseFirestore.instance.doc('/courses/$id');
+      FirestoreService.instance.doc('/courses/$id');
 }

--- a/lib/data/course_plan.dart
+++ b/lib/data/course_plan.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class CoursePlan {
   String? id;
@@ -37,8 +38,8 @@ class CoursePlan {
   };
 
   DocumentReference get docRef =>
-      FirebaseFirestore.instance.doc('/coursePlans/$id');
+      FirestoreService.instance.doc('/coursePlans/$id');
 
   static CollectionReference<Map<String, dynamic>> get collection =>
-      FirebaseFirestore.instance.collection('coursePlans');
+      FirestoreService.instance.collection('coursePlans');
 }

--- a/lib/data/data_helpers/course_profile_functions.dart
+++ b/lib/data/data_helpers/course_profile_functions.dart
@@ -1,9 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/course_profile.dart';
 
 class CourseProfileFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'courseProfiles';
 
   static Future<CourseProfile?> getCourseProfile(String courseId) async {

--- a/lib/data/data_helpers/instructor_dashboard_functions.dart
+++ b/lib/data/data_helpers/instructor_dashboard_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/user.dart';
 
@@ -12,8 +13,8 @@ class InstructorDashboardFunctions {
   /// Returns null on error or if the count is unavailable.
   static Future<int?> getStudentCount(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
-      final agg = await FirebaseFirestore.instance
+      final courseRef = FirestoreService.instance.doc('/courses/$courseId');
+      final agg = await FirestoreService.instance
           .collection('users')
           .where('enrolledCourseIds', arrayContains: courseRef)
           .count()
@@ -30,8 +31,8 @@ class InstructorDashboardFunctions {
   /// Returns null on error or if the count is unavailable.
   static Future<int?> getLessonCount(String courseId) async {
     try {
-      final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
-      final agg = await FirebaseFirestore.instance
+      final courseRef = FirestoreService.instance.doc('/courses/$courseId');
+      final agg = await FirestoreService.instance
           .collection('lessons')
           .where('courseId', isEqualTo: courseRef)
           .count()
@@ -47,7 +48,7 @@ class InstructorDashboardFunctions {
   /// Uses Firestore aggregation query. Returns null on error.
   static Future<int?> getSessionsTaughtCount(Course course) async {
     try {
-      final agg = await FirebaseFirestore.instance
+      final agg = await FirestoreService.instance
           .collection('practiceRecords')
           .where('courseId', isEqualTo: course.docRef)
           .where('menteeUid', isNotEqualTo: course.creatorId)
@@ -65,7 +66,7 @@ class InstructorDashboardFunctions {
   static Future<String?> _getTopStudentId(String courseId) async {
     print('Fetching top student ID for course $courseId');
     try {
-      final analyticsSnap = await FirebaseFirestore.instance
+      final analyticsSnap = await FirestoreService.instance
           .collection('courseAnalytics')
           .doc(courseId)
           .get();
@@ -90,7 +91,7 @@ class InstructorDashboardFunctions {
     }
 
     final userSnap =
-        await FirebaseFirestore.instance.collection('users').doc(topId).get();
+        await FirestoreService.instance.collection('users').doc(topId).get();
 
     print('Got most advanced student: ${userSnap.data()}');
     return userSnap.exists ? User.fromSnapshot(userSnap) : null;
@@ -111,8 +112,8 @@ class InstructorDashboardFunctions {
     StudentSortOption sort = StudentSortOption.alphabetical,
     String? nameFilter,
   }) async {
-    final courseRef = FirebaseFirestore.instance.doc('/courses/$courseId');
-    Query<Map<String, dynamic>> query = FirebaseFirestore.instance
+    final courseRef = FirestoreService.instance.doc('/courses/$courseId');
+    Query<Map<String, dynamic>> query = FirestoreService.instance
         .collection('users')
         .where('enrolledCourseIds', arrayContains: courseRef);
 

--- a/lib/data/data_helpers/learning_objective_functions.dart
+++ b/lib/data/data_helpers/learning_objective_functions.dart
@@ -1,9 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/learning_objective.dart';
 
 class LearningObjectiveFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'learningObjectives';
 
   static Future<List<LearningObjective>> getObjectivesForCourse(

--- a/lib/data/data_helpers/online_session_functions.dart
+++ b/lib/data/data_helpers/online_session_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/data_helpers/practice_record_functions.dart';
@@ -25,7 +26,7 @@ class OnlineSessionFunctions {
 
   static CollectionReference<Map<String, dynamic>>
       get _onlineSessionsCollection =>
-          FirebaseFirestore.instance.collection('onlineSessions');
+          FirestoreService.instance.collection('onlineSessions');
 
   /// Creates a new OnlineSession document in Firestore.
   /// The 'created' and 'lastActive' fields use the server timestamp.
@@ -308,7 +309,7 @@ class OnlineSessionFunctions {
 
     // Start transaction.
     bool success = false;
-    await FirebaseFirestore.instance.runTransaction((transaction) async {
+    await FirestoreService.instance.runTransaction((transaction) async {
       print('Start transaction to pair with session: $sessionId');
       var sessionRef = docRef('onlineSessions', sessionId);
       DocumentSnapshot<Map<String, dynamic>> snapshot =

--- a/lib/data/data_helpers/online_session_review_functions.dart
+++ b/lib/data/data_helpers/online_session_review_functions.dart
@@ -1,16 +1,17 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/online_session.dart';
 import 'package:social_learning/data/online_session_review.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class OnlineSessionReviewFunctions {
   static CollectionReference<Map<String, dynamic>> get _reviewCollection =>
-      FirebaseFirestore.instance.collection('onlineSessionReviews');
+      FirestoreService.instance.collection('onlineSessionReviews');
 
   static Future<void> createPendingReviewsForSession(
       OnlineSession session) async {
     // Build DocumentReferences for the session and lesson.
     DocumentReference sessionRef =
-        FirebaseFirestore.instance.collection('onlineSessions').doc(session.id);
+        FirestoreService.instance.collection('onlineSessions').doc(session.id);
     DocumentReference? lessonRef = session.lessonId;
     if (lessonRef == null) {
       print(
@@ -18,7 +19,7 @@ class OnlineSessionReviewFunctions {
       return;
     }
 
-    WriteBatch batch = FirebaseFirestore.instance.batch();
+    WriteBatch batch = FirestoreService.instance.batch();
 
     // Create the mentor's pending review.
     DocumentReference mentorReviewRef = _reviewCollection.doc();

--- a/lib/data/data_helpers/practice_record_functions.dart
+++ b/lib/data/data_helpers/practice_record_functions.dart
@@ -1,11 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/practice_record.dart';
 
 class PracticeRecordFunctions {
   static Future<List<DocumentReference>> getLearnedLessonIds(
       String menteeUid) async {
     // Query the practiceRecords collection for records where the user has graduated.
-    QuerySnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
+    QuerySnapshot<Map<String, dynamic>> snapshot = await FirestoreService
         .instance
         .collection('practiceRecords')
         .where('menteeUid', isEqualTo: menteeUid)
@@ -23,7 +24,7 @@ class PracticeRecordFunctions {
 
   /// Returns the count of graduated lessons where [menteeUid] is the student.
   static Future<int> getLessonsLearnedCount(String menteeUid) async {
-    final agg = await FirebaseFirestore.instance
+    final agg = await FirestoreService.instance
         .collection('practiceRecords')
         .where('menteeUid', isEqualTo: menteeUid)
         .where('isGraduation', isEqualTo: true)
@@ -34,7 +35,7 @@ class PracticeRecordFunctions {
 
   /// Returns the count of graduated lessons where [mentorUid] is the instructor.
   static Future<int> getLessonsTaughtCount(String mentorUid) async {
-    final agg = await FirebaseFirestore.instance
+    final agg = await FirestoreService.instance
         .collection('practiceRecords')
         .where('mentorUid', isEqualTo: mentorUid)
         .where('isGraduation', isEqualTo: true)
@@ -47,7 +48,7 @@ class PracticeRecordFunctions {
   /// for the given mentee UID.
   static Future<List<PracticeRecord>> fetchPracticeRecordsForMentee(
       String menteeUid) async {
-    final snapshot = await FirebaseFirestore.instance
+    final snapshot = await FirestoreService.instance
         .collection('practiceRecords')
         .where('menteeUid', isEqualTo: menteeUid)
         .get();

--- a/lib/data/data_helpers/progress_video_functions.dart
+++ b/lib/data/data_helpers/progress_video_functions.dart
@@ -1,6 +1,7 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
@@ -31,7 +32,7 @@ class ProgressVideoFunctions {
 
   static void createProgressVideo(
       Lesson lesson, User user, String youtubeUrl) async {
-    await FirebaseFirestore.instance
+    await FirestoreService.instance
         .collection('progressVideos')
         .add(<String, dynamic>{
       'userId': docRef('users', user.id),
@@ -52,7 +53,7 @@ class ProgressVideoFunctions {
       Widget Function(BuildContext context, List<ProgressVideo> progressVideos)
           builder) {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: FirebaseFirestore.instance
+        stream: FirestoreService.instance
             .collection('progressVideos')
             .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .snapshots(),
@@ -76,7 +77,7 @@ class ProgressVideoFunctions {
       Widget Function(BuildContext context, List<ProgressVideo> progressVideos)
           builder) {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: FirebaseFirestore.instance
+        stream: FirestoreService.instance
             .collection('progressVideos')
             .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .where('userId', isEqualTo: docRef('users', user.id))
@@ -100,7 +101,7 @@ class ProgressVideoFunctions {
       Widget Function(BuildContext context, List<ProgressVideo> progressVideos)
           builder) {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: FirebaseFirestore.instance
+        stream: FirestoreService.instance
             .collection('progressVideos')
             .where('lessonId', isEqualTo: docRef('lessons', lessonId))
             .where('isProfilePrivate', isNotEqualTo: true)
@@ -168,7 +169,7 @@ class ProgressVideoFunctions {
         docRef('courses', libraryState.selectedCourse?.id ?? '');
 
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: FirebaseFirestore.instance
+        stream: FirestoreService.instance
             .collection('progressVideos')
             .where('userId', isEqualTo: currentUserRef)
             .where('courseId', isEqualTo: currentDocRef)

--- a/lib/data/data_helpers/session_plan_activity_functions.dart
+++ b/lib/data/data_helpers/session_plan_activity_functions.dart
@@ -1,11 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/session_plan_activity.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 import '../session_play_activity_type.dart';
 
 class SessionPlanActivityFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'sessionPlanActivities';
 
   /// Create a new activity

--- a/lib/data/data_helpers/session_plan_block_functions.dart
+++ b/lib/data/data_helpers/session_plan_block_functions.dart
@@ -1,9 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/session_plan_block.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class SessionPlanBlockFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'sessionPlanBlocks';
 
   /// Create a new block under a session plan
@@ -117,7 +118,7 @@ class SessionPlanBlockFunctions {
 
   static Future<void> batchUpdateSortOrders(
       List<SessionPlanBlock> blocksToUpdate) async {
-    final batch = FirebaseFirestore.instance.batch();
+    final batch = FirestoreService.instance.batch();
 
     for (var block in blocksToUpdate) {
       if (block.id == null) continue;

--- a/lib/data/data_helpers/session_plan_functions.dart
+++ b/lib/data/data_helpers/session_plan_functions.dart
@@ -1,9 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/session_plan.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class SessionPlanFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'sessionPlans';
 
   /// Create a new session plan

--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -2,9 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/teachable_item_category.dart'; // For deleting items within a category
+import 'package:social_learning/data/firestore_service.dart';
 
 class TeachableItemCategoryFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'teachableItemCategories';
   static const String _itemsCollectionPath = 'teachableItems';
 
@@ -192,7 +193,7 @@ class TeachableItemCategoryFunctions {
     try {
       final courseRef = docRef('courses', courseId);
 
-      final snapshot = await FirebaseFirestore.instance
+      final snapshot = await FirestoreService.instance
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)
           .orderBy('sortOrder')

--- a/lib/data/data_helpers/teachable_item_functions.dart
+++ b/lib/data/data_helpers/teachable_item_functions.dart
@@ -2,9 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/teachable_item.dart';
 import 'package:social_learning/data/teachable_item_inclusion_status.dart';
+import 'package:social_learning/data/firestore_service.dart';
 
 class TeachableItemFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'teachableItems';
 
   static Future<TeachableItem?> addItem({
@@ -304,9 +305,9 @@ class TeachableItemFunctions {
   static Future<List<TeachableItem>> getItemsForCourse(String courseId) async {
     try {
       final courseRef =
-          FirebaseFirestore.instance.collection('courses').doc(courseId);
+          FirestoreService.instance.collection('courses').doc(courseId);
 
-      final snapshot = await FirebaseFirestore.instance
+      final snapshot = await FirestoreService.instance
           .collection(_collectionPath)
           .where('courseId', isEqualTo: courseRef)
           .get();
@@ -322,7 +323,7 @@ class TeachableItemFunctions {
 
   static Future<TeachableItem?> getItemById(String itemId) async {
     try {
-      final snapshot = await FirebaseFirestore.instance
+      final snapshot = await FirestoreService.instance
           .collection(_collectionPath)
           .doc(itemId)
           .get();

--- a/lib/data/data_helpers/teachable_item_tag_functions.dart
+++ b/lib/data/data_helpers/teachable_item_tag_functions.dart
@@ -1,9 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
 
 class TeachableItemTagFunctions {
-  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
   static const String _collectionPath = 'teachableItemTags';
   static const String _itemsCollectionPath = 'teachableItems';
 

--- a/test/belt_color_functions_test.dart
+++ b/test/belt_color_functions_test.dart
@@ -1,0 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('getBeltColor returns white for zero progress', () {
+    final color = BeltColorFunctions.getBeltColor(0);
+    expect(color, BeltColorFunctions.colors.first);
+  });
+}

--- a/test/course_plan_functions_test.dart
+++ b/test/course_plan_functions_test.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/course_plan_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('createCoursePlan then fetch by id', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final courseRef = fake.collection('courses').doc('c1');
+    final id = await CoursePlanFunctions.createCoursePlan(courseRef, 'plan');
+    final plan = await CoursePlanFunctions.getCoursePlanById(id);
+    expect(plan?.planJson, 'plan');
+  });
+}

--- a/test/course_profile_functions_test.dart
+++ b/test/course_profile_functions_test.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/course_profile.dart';
+import 'package:social_learning/data/data_helpers/course_profile_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('saveCourseProfile then load', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final profile = CourseProfile(
+      courseId: fake.collection('courses').doc('c1'),
+      topicAndFocus: 'topic',
+      defaultTeachableItemDurationInMinutes: 10,
+      instructionalTimePercent: 70,
+    );
+    final saved = await CourseProfileFunctions.saveCourseProfile(profile);
+    expect(saved.courseId.path, '/courses/c1');
+  });
+}

--- a/test/instructor_dashboard_functions_test.dart
+++ b/test/instructor_dashboard_functions_test.dart
@@ -1,0 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/instructor_dashboard_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('getStudentCount returns number of enrolled users', () async {
+    final courseRef = fake.collection('courses').doc('c1');
+    await courseRef.set({'title': 't'});
+    await fake.collection('users').add({'enrolledCourseIds': [courseRef]});
+    await fake.collection('users').add({'enrolledCourseIds': [courseRef]});
+    final count = await InstructorDashboardFunctions.getStudentCount('c1');
+    expect(count, 2);
+  });
+}

--- a/test/learning_objective_functions_test.dart
+++ b/test/learning_objective_functions_test.dart
@@ -1,0 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/learning_objective_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('addObjective creates and fetches objective', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final obj = await LearningObjectiveFunctions.addObjective(
+        courseId: 'c1', name: 'obj', sortOrder: 0);
+    final list = await LearningObjectiveFunctions.getObjectivesForCourse('c1');
+    expect(list.first.name, 'obj');
+    expect(obj.name, 'obj');
+  });
+}

--- a/test/online_session_functions_test.dart
+++ b/test/online_session_functions_test.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/online_session_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/online_session.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('createOnlineSession then load', () async {
+    final courseRef = fake.collection('courses').doc('c1');
+    await courseRef.set({'title': 't'});
+    final session = OnlineSession(
+      courseId: courseRef,
+      learnerUid: 'l',
+      mentorUid: 'm',
+      isMentorInitiated: false,
+      status: OnlineSessionStatus.waiting,
+    );
+    final ref = await OnlineSessionFunctions.createOnlineSession(session);
+    final loaded = await OnlineSessionFunctions.getOnlineSession(ref.id);
+    expect(loaded.mentorUid, 'm');
+  });
+}

--- a/test/online_session_review_functions_test.dart
+++ b/test/online_session_review_functions_test.dart
@@ -1,0 +1,50 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/online_session_review_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/online_session.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('createPendingReviewsForSession creates two reviews', () async {
+    final courseRef = fake.collection('courses').doc('c1');
+    final lessonRef = fake.collection('lessons').doc('l1');
+    await courseRef.set({'title': 't'});
+    await lessonRef.set({'name': 'lesson'});
+    final session = OnlineSession(
+      id: 's1',
+      courseId: courseRef,
+      learnerUid: 'l',
+      mentorUid: 'm',
+      isMentorInitiated: false,
+      status: OnlineSessionStatus.active,
+      lessonId: lessonRef,
+    );
+    await fake.collection('onlineSessions').doc('s1').set({
+      'courseId': courseRef,
+      'learnerUid': 'l',
+      'mentorUid': 'm',
+      'videoCallUrl': null,
+      'isMentorInitiated': false,
+      'status': OnlineSessionStatus.active.code,
+      'created': Timestamp.now(),
+      'lastActive': Timestamp.now(),
+      'pairedAt': Timestamp.now(),
+      'lessonId': lessonRef,
+    });
+    await OnlineSessionReviewFunctions.createPendingReviewsForSession(session);
+    final reviews = await fake.collection('onlineSessionReviews').get();
+    expect(reviews.docs.length, 2);
+  });
+}

--- a/test/practice_record_functions_test.dart
+++ b/test/practice_record_functions_test.dart
@@ -1,0 +1,33 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/practice_record_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('getLessonsLearnedCount returns count of graduated lessons', () async {
+    await fake.collection('practiceRecords').add({
+      'menteeUid': 'u1',
+      'isGraduation': true,
+      'lessonId': fake.doc('lessons/l1'),
+    });
+    await fake.collection('practiceRecords').add({
+      'menteeUid': 'u1',
+      'isGraduation': true,
+      'lessonId': fake.doc('lessons/l2'),
+    });
+    final count = await PracticeRecordFunctions.getLessonsLearnedCount('u1');
+    expect(count, 2);
+  });
+}

--- a/test/progress_video_functions_test.dart
+++ b/test/progress_video_functions_test.dart
@@ -1,0 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/progress_video_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('extractYouTubeVideoId parses ID from URL', () {
+    final id = ProgressVideoFunctions.extractYouTubeVideoId('https://youtu.be/ABCDEFG1234');
+    expect(id, 'ABCDEFG1234');
+  });
+}

--- a/test/session_plan_activity_functions_test.dart
+++ b/test/session_plan_activity_functions_test.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/session_plan_activity_functions.dart';
+import 'package:social_learning/data/data_helpers/session_plan_block_functions.dart';
+import 'package:social_learning/data/data_helpers/session_plan_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/session_plan_activity.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('create session plan activity', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final plan = await SessionPlanFunctions.create(courseId: 'c1', name: 'p');
+    final block = await SessionPlanBlockFunctions.create(
+        courseId: 'c1', sessionPlanId: plan!.id!, name: 'b', sortOrder: 0);
+    final act = await SessionPlanActivityFunctions.create(
+      courseId: 'c1',
+      sessionPlanId: plan.id!,
+      sessionPlanBlockId: block!.id!,
+      activityType: SessionPlanActivityType.lesson,
+      sortOrder: 0,
+    );
+    expect(act?.activityType, SessionPlanActivityType.lesson);
+  });
+}

--- a/test/session_plan_block_functions_test.dart
+++ b/test/session_plan_block_functions_test.dart
@@ -1,0 +1,27 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/session_plan_block_functions.dart';
+import 'package:social_learning/data/data_helpers/session_plan_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('create session plan block', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final plan = await SessionPlanFunctions.create(courseId: 'c1', name: 'p');
+    final block = await SessionPlanBlockFunctions.create(
+        courseId: 'c1', sessionPlanId: plan!.id!, name: 'b', sortOrder: 0);
+    expect(block?.name, 'b');
+  });
+}

--- a/test/session_plan_functions_test.dart
+++ b/test/session_plan_functions_test.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/session_plan_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('create session plan', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final plan = await SessionPlanFunctions.create(courseId: 'c1', name: 'plan');
+    expect(plan?.name, 'plan');
+  });
+}

--- a/test/teachable_item_category_functions_test.dart
+++ b/test/teachable_item_category_functions_test.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('addCategory creates a category', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    expect(cat?.name, 'cat');
+  });
+}

--- a/test/teachable_item_functions_test.dart
+++ b/test/teachable_item_functions_test.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('addItem creates a teachable item', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final item = await TeachableItemFunctions.addItem(courseId: 'c1', categoryId: cat!.id!, name: 'item');
+    expect(item?.name, 'item');
+  });
+}

--- a/test/teachable_item_tag_functions_test.dart
+++ b/test/teachable_item_tag_functions_test.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_tag_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = FirebaseFirestore.instance;
+  });
+
+  test('addTag creates a tag', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final tag = await TeachableItemTagFunctions.addTag(courseId: 'c1', name: 't', color: 'blue');
+    expect(tag?.name, 't');
+  });
+}


### PR DESCRIPTION
## Summary
- split the previous combined `functions_tests.dart` into one file per XxxFunctions
- use `FirestoreService.instance` in tests to inject FakeFirebaseFirestore

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5f547c7c832e80cdaa79d09a109d