### PR TITLE
Lazy Firestore wrapper for tests

### DIFF
--- a/lib/data/firestore_service.dart
+++ b/lib/data/firestore_service.dart
@@ -4,6 +4,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 /// instance in tests.
 class FirestoreService {
   /// The Firestore instance used by the app. Tests can replace this
-  /// with a [FakeFirebaseFirestore].
-  static FirebaseFirestore instance = FirebaseFirestore.instance;
+  /// with a [FakeFirebaseFirestore]. When `null`, the default
+  /// [FirebaseFirestore.instance] will be lazily obtained on first use.
+  static FirebaseFirestore? _instance;
+
+  static FirebaseFirestore get instance =>
+      _instance ??= FirebaseFirestore.instance;
+
+  static set instance(FirebaseFirestore? firestore) {
+    _instance = firestore;
+  }
 }

--- a/test/belt_color_functions_test.dart
+++ b/test/belt_color_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('getBeltColor returns white for zero progress', () {

--- a/test/course_plan_functions_test.dart
+++ b/test/course_plan_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('createCoursePlan then fetch by id', () async {

--- a/test/course_profile_functions_test.dart
+++ b/test/course_profile_functions_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('saveCourseProfile then load', () async {

--- a/test/instructor_dashboard_functions_test.dart
+++ b/test/instructor_dashboard_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('getStudentCount returns number of enrolled users', () async {

--- a/test/learning_objective_functions_test.dart
+++ b/test/learning_objective_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('addObjective creates and fetches objective', () async {

--- a/test/online_session_functions_test.dart
+++ b/test/online_session_functions_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('createOnlineSession then load', () async {

--- a/test/online_session_review_functions_test.dart
+++ b/test/online_session_review_functions_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('createPendingReviewsForSession creates two reviews', () async {

--- a/test/practice_record_functions_test.dart
+++ b/test/practice_record_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('getLessonsLearnedCount returns count of graduated lessons', () async {

--- a/test/progress_video_functions_test.dart
+++ b/test/progress_video_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('extractYouTubeVideoId parses ID from URL', () {

--- a/test/session_plan_activity_functions_test.dart
+++ b/test/session_plan_activity_functions_test.dart
@@ -16,7 +16,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('create session plan activity', () async {

--- a/test/session_plan_block_functions_test.dart
+++ b/test/session_plan_block_functions_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('create session plan block', () async {

--- a/test/session_plan_functions_test.dart
+++ b/test/session_plan_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('create session plan', () async {

--- a/test/teachable_item_category_functions_test.dart
+++ b/test/teachable_item_category_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('addCategory creates a category', () async {

--- a/test/teachable_item_functions_test.dart
+++ b/test/teachable_item_functions_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('addItem creates a teachable item', () async {

--- a/test/teachable_item_tag_functions_test.dart
+++ b/test/teachable_item_tag_functions_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('addTag creates a tag', () async {

--- a/test/user_functions_test.dart
+++ b/test/user_functions_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   tearDown(() {
-    FirestoreService.instance = FirebaseFirestore.instance;
+    FirestoreService.instance = null;
   });
 
   test('getUserById retrieves the user document', () async {


### PR DESCRIPTION
## Summary
- make `FirestoreService` lazily initialize `FirebaseFirestore`
- reset wrapper to `null` in tests so Firebase isn't initialized

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d65358210832ebb59c297c574ff6d