### PR TITLE
Fix compile errors in CourseDesigner

### DIFF
--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/cloud_functions/cloud_functions.dart';
 import 'package:social_learning/cloud_functions/inventory_generation_response.dart';
 import 'package:social_learning/data/course.dart';
@@ -675,6 +676,7 @@ class CourseDesignerState extends ChangeNotifier {
     }
   }
 
+
   List<TeachableItem> getItemsForCategory(String categoryId) {
     return items.where((item) => item.categoryId.id == categoryId).toList()
       ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
@@ -960,7 +962,7 @@ class CourseDesignerState extends ChangeNotifier {
     final newActivity = await SessionPlanActivityFunctions.create(
       courseId: _activeCourse!.id!,
       sessionPlanId: sessionPlan!.id!,
-      blockId: blockId,
+      sessionPlanBlockId: blockId,
       lessonId: lessonId,
       name: name,
       notes: notes,

--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -6,6 +6,11 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer/cou
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_category_entry.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 
@@ -103,8 +108,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
 
   List<InventoryEntry> _buildEntries(CourseDesignerState state) {
     final entries = <InventoryEntry>[];
-    final categories = [...state.categories]
-      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    final categories = state.categories;
     for (final category in categories) {
       final expanded = _expanded[category.id!] ?? true;
       final catEntry = InventoryCategoryEntry(

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart
@@ -52,17 +52,17 @@ class InventoryDragHelper {
     final target = inventoryEntries[newIndex];
 
     if (target is InventoryCategoryEntry) {
-      newSortOrder = context.getCategories().indexWhere((c) => c.id == target.category.id);
+      newSortOrder = context.categories.indexWhere((c) => c.id == target.category.id);
     } else if (target is InventoryItemEntry || target is AddNewItemEntry) {
       final targetCategoryId = target is InventoryItemEntry
           ? target.item.categoryId.id
           : (target as AddNewItemEntry).category.id;
 
       final targetIndex =
-      context.getCategories().indexWhere((c) => c.id == targetCategoryId);
+      context.categories.indexWhere((c) => c.id == targetCategoryId);
       newSortOrder = targetIndex + 1;
     } else if (target is AddNewCategoryEntry) {
-      newSortOrder = context.getCategories().length - 1;
+      newSortOrder = context.categories.length - 1;
     } else {
       return;
     }
@@ -70,7 +70,7 @@ class InventoryDragHelper {
     await TeachableItemCategoryFunctions.updateCategorySortOrder(
       movedCategory: draggedCategory,
       newIndex: newSortOrder,
-      allCategoriesForCourse: context.getCategories(),
+      allCategoriesForCourse: context.categories,
     );
   }
 
@@ -81,7 +81,7 @@ class InventoryDragHelper {
     required int newIndex,
   }) async {
     final draggedItem = draggedEntry.item;
-    final allItems = context.getItems();
+    final allItems = context.items;
     final target = inventoryEntries[newIndex];
 
     DocumentReference newCategoryRef;
@@ -104,9 +104,7 @@ class InventoryDragHelper {
       newCategoryRef = docRef('teachableItemCategories', target.category.id!);
       newIndexInCategory = 0;
     } else if (target is AddNewCategoryEntry) {
-      final lastCategory = (context.getCategories()
-        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder)))
-          .last;
+      final lastCategory = context.categories.last;
 
       newCategoryRef = docRef('teachableItemCategories', lastCategory.id!);
 


### PR DESCRIPTION
## Summary
- remove unused getters and rely on sorted collections
- use `categories` and `items` properties instead of new helper methods
- clean up inventory drag helper

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d66ee0e20832eafd474a43f9784bc