### PR TITLE
feat: add course home dashboard

### DIFF
--- a/lib/data/data_helpers/progress_video_functions.dart
+++ b/lib/data/data_helpers/progress_video_functions.dart
@@ -232,4 +232,32 @@ class ProgressVideoFunctions {
         progressVideosByLessonId.values.toList();
     return progressVideosList;
   }
+
+  static Stream<QuerySnapshot<Map<String, dynamic>>> streamCourseVideos(
+      String courseId,
+      {int limit = 5}) {
+    return FirestoreService.instance
+        .collection('progressVideos')
+        .where('courseId', isEqualTo: docRef('courses', courseId))
+        .where('isProfilePrivate', isNotEqualTo: true)
+        .orderBy('timestamp', descending: true)
+        .limit(limit)
+        .snapshots();
+  }
+
+  static Future<QuerySnapshot<Map<String, dynamic>>> fetchCourseVideos(
+      String courseId,
+      {DocumentSnapshot? startAfter,
+      int limit = 5}) {
+    Query<Map<String, dynamic>> query = FirestoreService.instance
+        .collection('progressVideos')
+        .where('courseId', isEqualTo: docRef('courses', courseId))
+        .where('isProfilePrivate', isNotEqualTo: true)
+        .orderBy('timestamp', descending: true)
+        .limit(limit);
+    if (startAfter != null) {
+      query = query.startAfterDocument(startAfter);
+    }
+    return query.get();
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:social_learning/ui_foundation/course_generation_review_page.dart
 import 'package:social_learning/ui_foundation/course_create_page.dart';
 import 'package:social_learning/ui_foundation/course_generation_page.dart';
 import 'package:social_learning/ui_foundation/home_page.dart';
+import 'package:social_learning/ui_foundation/course_home_page.dart';
 import 'package:social_learning/ui_foundation/instructor_dashboard_page.dart';
 import 'package:social_learning/ui_foundation/landing_page.dart';
 import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
@@ -142,6 +143,7 @@ class SocialLearningApp extends StatelessWidget {
       routes: {
         '/landing': (context) => const LandingPage(),
         '/home': (context) => const HomePage(),
+        '/course_home': (context) => const CourseHomePage(),
         '/profile': (context) => const ProfilePage(),
         '/other_profile': (context) => const OtherProfilePage(),
         '/profile_comparison': (context) => const ProfileComparisonPage(),

--- a/lib/ui_foundation/course_home_page.dart
+++ b/lib/ui_foundation/course_home_page.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_home/progress_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_home/next_lesson_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_home/progress_video_feed.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+class CourseHomePage extends StatefulWidget {
+  const CourseHomePage({super.key});
+
+  @override
+  State<CourseHomePage> createState() => _CourseHomePageState();
+}
+
+class _CourseHomePageState extends State<CourseHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    LibraryState libraryState = Provider.of<LibraryState>(context);
+    if (libraryState.selectedCourse == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        NavigationEnum.home.navigateClean(context);
+      });
+    }
+    var course = libraryState.selectedCourse;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(course?.title ?? ''),
+        actions: [
+          IconButton(
+              onPressed: () {
+                if (course != null) {
+                  showModalBottomSheet(
+                      context: context,
+                      builder: (context) => Padding(
+                            padding: const EdgeInsets.all(16.0),
+                            child: Text(course.description ?? ''),
+                          ));
+                }
+              },
+              icon: const Icon(Icons.info_outline)),
+          IconButton(
+              onPressed: () {
+                NavigationEnum.home.navigateClean(context);
+              },
+              icon: const Icon(Icons.switch_right))
+        ],
+      ),
+      bottomNavigationBar: BottomBarV2.build(context),
+      body: Align(
+          alignment: Alignment.topCenter,
+          child: CustomUiConstants.framePage(Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: const [
+                  Expanded(child: ProgressCard()),
+                  SizedBox(width: 8),
+                  Expanded(child: NextLessonCard()),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text('Recent progress', style: CustomTextStyles.subHeadline),
+              const SizedBox(height: 8),
+              const ProgressVideoFeed(),
+            ],
+          ))),
+    );
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
+++ b/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
@@ -138,7 +138,8 @@ class BottomBarV2 {
       return -1;
     }
 
-    if (currentRoute == NavigationEnum.home.route) {
+    if ({NavigationEnum.home.route, NavigationEnum.courseHome.route}
+        .contains(currentRoute)) {
       return 0;
     } else if (isLessonsVisible &&
         {
@@ -228,8 +229,12 @@ class BottomBarV2 {
 
     // Home
     if (index == 0) {
-      Navigator.of(context)
-          .pushNamedAndRemoveUntil(NavigationEnum.home.route, (route) => false);
+      if (libraryState.isCourseSelected) {
+        NavigationEnum.courseHome.navigateClean(context);
+      } else {
+        Navigator.of(context).pushNamedAndRemoveUntil(
+            NavigationEnum.home.route, (route) => false);
+      }
       return;
     } else {
       index--;

--- a/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/lesson.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/state/student_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/lesson_cover_image_widget.dart';
+import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+
+class NextLessonCard extends StatelessWidget {
+  const NextLessonCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<StudentState, LibraryState>(
+        builder: (context, studentState, libraryState, child) {
+      var lessons = libraryState.lessons;
+      var course = libraryState.selectedCourse;
+      if (lessons == null || course == null) {
+        return const SizedBox.shrink();
+      }
+      List<String> completed = studentState.getGraduatedLessonIds();
+      List<Lesson> remaining = lessons
+          .where((l) => l.courseId.id == course.id)
+          .where((l) => !completed.contains(l.id))
+          .toList()
+        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+      if (remaining.isEmpty) {
+        return Card(
+            child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('All lessons completed!',
+                    style: CustomTextStyles.getBody(context))));
+      }
+      Lesson lesson = remaining.first;
+      return Card(
+          child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          LessonCoverImageWidget(lesson.coverFireStoragePath),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child:
+                Text(lesson.title, style: CustomTextStyles.getBody(context)),
+          ),
+          Align(
+              alignment: Alignment.bottomRight,
+              child: Padding(
+                  padding: const EdgeInsets.only(right: 8, bottom: 8),
+                  child: ElevatedButton.icon(
+                      onPressed: () =>
+                          LessonDetailArgument.goToLessonDetailPage(
+                              context, lesson.id!),
+                      icon: const Icon(Icons.play_arrow),
+                      label: const Text('Start'))))
+        ],
+      ));
+    });
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/state/student_state.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+
+class ProgressCard extends StatelessWidget {
+  const ProgressCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<StudentState, LibraryState>(
+        builder: (context, studentState, libraryState, child) {
+      Course? course = libraryState.selectedCourse;
+      var lessons = libraryState.lessons;
+      if (course == null || lessons == null) {
+        return const SizedBox.shrink();
+      }
+      int totalLessons =
+          lessons.where((l) => l.courseId.id == course.id).length;
+      int completed = studentState.getLessonsLearned(course, libraryState);
+      double progress =
+          totalLessons == 0 ? 0 : completed / totalLessons.toDouble();
+      Color beltColor = BeltColorFunctions.getBeltColor(progress);
+      return Card(
+          child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      double size = constraints.maxWidth;
+                      return SizedBox(
+                        height: size,
+                        width: size,
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            CircularProgressIndicator(
+                              value: progress,
+                              strokeWidth: 8,
+                              valueColor:
+                                  AlwaysStoppedAnimation<Color>(beltColor),
+                              backgroundColor: beltColor.withOpacity(.25),
+                            ),
+                            Text('$completed of $totalLessons\nlessons completed',
+                                textAlign: TextAlign.center,
+                                style:
+                                    CustomTextStyles.getBody(context))
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              )));
+    });
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/course_home/progress_video_feed.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_video_feed.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/data_helpers/progress_video_functions.dart';
+import 'package:social_learning/data/progress_video.dart';
+import 'package:social_learning/data/user.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/youtube_video_widget.dart';
+import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+
+class ProgressVideoFeed extends StatefulWidget {
+  const ProgressVideoFeed({super.key});
+
+  @override
+  State<ProgressVideoFeed> createState() => _ProgressVideoFeedState();
+}
+
+class _ProgressVideoFeedState extends State<ProgressVideoFeed> {
+  static const int _pageSize = 5;
+
+  final List<ProgressVideo> _streamVideos = [];
+  final List<ProgressVideo> _moreVideos = [];
+  DocumentSnapshot? _lastDocument;
+  bool _hasMore = true;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  void _subscribe() {
+    LibraryState libraryState =
+        Provider.of<LibraryState>(context, listen: false);
+    String? courseId = libraryState.selectedCourse?.id;
+    if (courseId == null) {
+      return;
+    }
+    _subscription = ProgressVideoFunctions.streamCourseVideos(courseId,
+            limit: _pageSize)
+        .listen((snapshot) {
+      setState(() {
+        _streamVideos.clear();
+        _streamVideos.addAll(
+            ProgressVideoFunctions.convertSnapshotToSortedProgressVideos(
+                snapshot));
+        if (snapshot.docs.isNotEmpty) {
+          _lastDocument = snapshot.docs.last;
+          _hasMore = snapshot.docs.length == _pageSize;
+        } else {
+          _lastDocument = null;
+          _hasMore = false;
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadMore() async {
+    if (!_hasMore) return;
+    LibraryState libraryState =
+        Provider.of<LibraryState>(context, listen: false);
+    String? courseId = libraryState.selectedCourse?.id;
+    if (courseId == null) return;
+    QuerySnapshot<Map<String, dynamic>> snapshot =
+        await ProgressVideoFunctions.fetchCourseVideos(courseId,
+            startAfter: _lastDocument, limit: _pageSize);
+    List<ProgressVideo> newVideos =
+        snapshot.docs.map((e) => ProgressVideo.fromSnapshot(e)).toList();
+    setState(() {
+      _moreVideos.addAll(newVideos);
+      if (snapshot.docs.isNotEmpty) {
+        _lastDocument = snapshot.docs.last;
+        _hasMore = snapshot.docs.length == _pageSize;
+      } else {
+        _hasMore = false;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List<ProgressVideo> allVideos = [..._streamVideos, ..._moreVideos];
+    if (allVideos.isEmpty) {
+      return Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text('No progress videos yet – be the first to upload!',
+              style: CustomTextStyles.getBody(context)));
+    }
+    return ListView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: allVideos.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= allVideos.length) {
+            _loadMore();
+            return const Center(child: CircularProgressIndicator());
+          }
+          ProgressVideo video = allVideos[index];
+          LibraryState libraryState =
+              Provider.of<LibraryState>(context, listen: false);
+          var lesson = libraryState.findLesson(video.lessonId.id);
+          String lessonTitle = lesson?.title ?? 'Lesson';
+          return Card(
+              child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            ProfileImageByUserIdWidget(video.userId, libraryState),
+                            const SizedBox(width: 8),
+                            FutureBuilder<User>(
+                                future:
+                                    UserFunctions.getUserById(video.userId.id),
+                                builder: (context, snapshot) {
+                                  String name =
+                                      snapshot.data?.displayName ?? 'Student';
+                                  return Text(name,
+                                      style:
+                                          CustomTextStyles.getBody(context));
+                                }),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        if (video.youtubeVideoId != null)
+                          YouTubeVideoWidget(videoId: video.youtubeVideoId!),
+                        const SizedBox(height: 8),
+                        InkWell(
+                          onTap: () => LessonDetailArgument.goToLessonDetailPage(
+                              context, video.lessonId.id),
+                          child: Text(lessonTitle,
+                              style: CustomTextStyles.getBody(context).copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .primary)),
+                        ),
+                        if (video.timestamp != null)
+                          Text(video.timestamp!.toDate().toString(),
+                              style: CustomTextStyles.getBodySmall(context)),
+                      ])));
+        });
+  }
+}
+

--- a/lib/ui_foundation/ui_constants/navigation_enum.dart
+++ b/lib/ui_foundation/ui_constants/navigation_enum.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 enum NavigationEnum {
   landing('/landing'),
   home('/home'),
+  courseHome('/course_home'),
   profile('/profile'),
   otherProfile('/other_profile'),
   profileComparison('/profile_comparison'),


### PR DESCRIPTION
## Summary
- add course-focused home page with progress, next lesson, and recent video feed widgets
- stream and paginate course progress videos
- smart bottom bar navigation routes to course selection when no course chosen
- make progress dial responsive and allow clicking feed lesson titles

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3d3cfa2c832e89855afc8fbad14b