### PR TITLE
feat: smart home redirects

### DIFF
--- a/lib/ui_foundation/bottom_bar.dart
+++ b/lib/ui_foundation/bottom_bar.dart
@@ -16,7 +16,15 @@ class BottomBar extends StatelessWidget {
         child: Consumer<ApplicationState>(
             builder: (context, applicationState, child) => Row(
                   children: [
-                    addIcon(context, Icons.home, NavigationEnum.home, true),
+                    Consumer<LibraryState>(
+                      builder: (context, libraryState, child) => addIcon(
+                          context,
+                          Icons.home,
+                          libraryState.isCourseSelected
+                              ? NavigationEnum.courseHome
+                              : NavigationEnum.home,
+                          true),
+                    ),
                     Consumer<LibraryState>(
                       builder: (context, libraryState, child) => addIcon(
                           context,
@@ -92,8 +100,9 @@ class BottomBar extends StatelessWidget {
     } else if (libraryState.isCourseSelected && applicationState.isLoggedIn) {
       return NavigationEnum.sessionHome;
     } else {
-      // The user needs to select a course first.
-      return NavigationEnum.sessionHome;
+      return libraryState.isCourseSelected
+          ? NavigationEnum.courseHome
+          : NavigationEnum.home;
     }
   }
 }

--- a/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
+++ b/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
@@ -7,7 +7,7 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 
 /// This is an invisible widget for the landing page. It checks if the user
 /// is still signed in and then re-directs either to the home page or the
-/// curriculum page for the selected course.
+/// course home page for the selected course.
 class AutoSignInWidget extends StatefulWidget {
   const AutoSignInWidget({super.key});
 
@@ -42,8 +42,6 @@ class AutoSignInWidgetState extends State<AutoSignInWidget> {
       return;
     }
 
-    // If the user doesn't have a course selected, we can re-direct to the home
-    // page right away.
     if (currentUser.currentCourseId == null) {
       _isRedirecting = true;
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -54,17 +52,25 @@ class AutoSignInWidgetState extends State<AutoSignInWidget> {
       return;
     }
 
-    // If the user has a course selected, wait for the course to be loaded.
+    await libraryState.ensureSelectedCourseLoaded();
+
     if (libraryState.selectedCourse != null) {
       _isRedirecting = true;
       SchedulerBinding.instance.addPostFrameCallback((_) {
         if (context.mounted) {
-          print('Going from the landing page to the level page.');
+          print('Going from the landing page to the course home page.');
           Navigator.of(context)
-              .pushReplacementNamed(NavigationEnum.levelList.route);
+              .pushReplacementNamed(NavigationEnum.courseHome.route);
         }
       });
       return;
     }
+
+    _isRedirecting = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (context.mounted) {
+        Navigator.of(context).pushReplacementNamed(NavigationEnum.home.route);
+      }
+    });
   }
 }

--- a/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
+++ b/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
@@ -116,8 +116,9 @@ class BottomBarV2 {
     } else if (libraryState.isCourseSelected && applicationState.isLoggedIn) {
       return NavigationEnum.sessionHome;
     } else {
-      // The user needs to select a course first.
-      return NavigationEnum.home;
+      return libraryState.isCourseSelected
+          ? NavigationEnum.courseHome
+          : NavigationEnum.home;
     }
   }
 

--- a/lib/ui_foundation/helper_widgets/general/creator_guard.dart
+++ b/lib/ui_foundation/helper_widgets/general/creator_guard.dart
@@ -34,7 +34,11 @@ class CreatorGuardState extends State<CreatorGuard> {
         if (!_navigationScheduled) {
           _navigationScheduled = true;
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            NavigationEnum.home.navigateCleanDelayed(context);
+            if (libraryState.isCourseSelected) {
+              NavigationEnum.courseHome.navigateCleanDelayed(context);
+            } else {
+              NavigationEnum.home.navigateCleanDelayed(context);
+            }
           });
         }
         return const SizedBox();  // render nothing while redirecting

--- a/lib/ui_foundation/sign_in_page.dart
+++ b/lib/ui_foundation/sign_in_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/data_helpers/user_functions.dart';
 import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class SignInPage extends StatelessWidget {
@@ -39,9 +40,20 @@ class SignInPage extends StatelessWidget {
 
             ApplicationState applicationState =
                 Provider.of<ApplicationState>(context, listen: false);
-            if ((await applicationState.currentUserBlocking)?.currentCourseId != null) {
-              Navigator.of(context).pushNamedAndRemoveUntil(
-                  NavigationEnum.levelList.route, (Route<dynamic> route) => false);
+            LibraryState libraryState =
+                Provider.of<LibraryState>(context, listen: false);
+            if ((await applicationState.currentUserBlocking)?.currentCourseId !=
+                null) {
+              await libraryState.ensureSelectedCourseLoaded();
+              if (libraryState.selectedCourse != null) {
+                Navigator.of(context).pushNamedAndRemoveUntil(
+                    NavigationEnum.courseHome.route,
+                    (Route<dynamic> route) => false);
+              } else {
+                Navigator.of(context).pushNamedAndRemoveUntil(
+                    NavigationEnum.home.route,
+                    (Route<dynamic> route) => false);
+              }
             } else {
               Navigator.of(context).pushNamedAndRemoveUntil(
                   NavigationEnum.home.route, (Route<dynamic> route) => false);


### PR DESCRIPTION
## Summary
- Redirect bottom bar home icon and session button based on whether a course is selected
- Auto and sign-in flows wait for LibraryState and send users to course home when a course exists
- Guards send unauthorized users to the appropriate home page

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e523d48f4832e9a3ede8ba86d0188