### PR TITLE
Fix course profile test path expectation

### DIFF
--- a/test/course_profile_functions_test.dart
+++ b/test/course_profile_functions_test.dart
@@ -26,6 +26,6 @@ void main() {
       instructionalTimePercent: 70,
     );
     final saved = await CourseProfileFunctions.saveCourseProfile(profile);
-    expect(saved.courseId.path, '/courses/c1');
+    expect(saved.courseId.path, 'courses/c1');
   });
 }


### PR DESCRIPTION
## Summary
- correct course profile test to expect `courses/c1` path without leading slash

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e53839090832e9b2be77d147d14ab