### PR TITLE
refactor: replace nested consumers

### DIFF
--- a/lib/ui_foundation/bottom_bar.dart
+++ b/lib/ui_foundation/bottom_bar.dart
@@ -13,53 +13,38 @@ class BottomBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BottomAppBar(
-        child: Consumer<ApplicationState>(
-            builder: (context, applicationState, child) => Row(
+        child: Consumer4<ApplicationState, LibraryState, StudentSessionState,
+            OrganizerSessionState>(
+            builder: (context, applicationState, libraryState, studentSessionState,
+                    organizerSessionState, child) =>
+                Row(
                   children: [
-                    Consumer<LibraryState>(
-                      builder: (context, libraryState, child) => addIcon(
-                          context,
-                          Icons.home,
-                          libraryState.isCourseSelected
-                              ? NavigationEnum.courseHome
-                              : NavigationEnum.home,
-                          true),
-                    ),
-                    Consumer<LibraryState>(
-                      builder: (context, libraryState, child) => addIcon(
-                          context,
-                          Icons.list_alt_rounded,
-                          NavigationEnum.levelList,
-                          libraryState.isCourseSelected &&
-                              applicationState.isLoggedIn),
-                    ),
-                    Consumer<LibraryState>(
-                        builder: (context, libraryState, child) =>
-                            _isCourseAdmin(applicationState, libraryState)
-                                ? addIcon(context, Icons.settings,
-                                    NavigationEnum.cmsSyllabus, true)
-                                : const Spacer()),
-                    Consumer<StudentSessionState>(
-                      builder: (context, studentSessionState, child) =>
-                          Consumer<OrganizerSessionState>(
-                        builder: (context, organizerSessionState, child) =>
-                            Consumer<LibraryState>(
-                          builder: (context, libraryState, child) => addIcon(
-                            context,
-                            Icons.calendar_today,
-                            _getSessionNavigationTarget(
-                                applicationState,
-                                libraryState,
-                                studentSessionState,
-                                organizerSessionState),
-                            applicationState.isLoggedIn &&
-                                (libraryState.isCourseSelected ||
-                                    studentSessionState.isInitialized ||
-                                    organizerSessionState.isInitialized),
-                          ),
-                        ),
-                      ),
-                    ),
+                    addIcon(
+                        context,
+                        Icons.home,
+                        libraryState.isCourseSelected
+                            ? NavigationEnum.courseHome
+                            : NavigationEnum.home,
+                        true),
+                    addIcon(
+                        context,
+                        Icons.list_alt_rounded,
+                        NavigationEnum.levelList,
+                        libraryState.isCourseSelected &&
+                            applicationState.isLoggedIn),
+                    _isCourseAdmin(applicationState, libraryState)
+                        ? addIcon(context, Icons.settings,
+                            NavigationEnum.cmsSyllabus, true)
+                        : const Spacer(),
+                    addIcon(
+                        context,
+                        Icons.calendar_today,
+                        _getSessionNavigationTarget(applicationState, libraryState,
+                            studentSessionState, organizerSessionState),
+                        applicationState.isLoggedIn &&
+                            (libraryState.isCourseSelected ||
+                                studentSessionState.isInitialized ||
+                                organizerSessionState.isInitialized)),
                     addIcon(context, Icons.person, NavigationEnum.profile,
                         applicationState.isLoggedIn),
                   ],

--- a/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
+++ b/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
@@ -9,81 +9,75 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 
 class BottomBarV2 {
   static Widget build(BuildContext context) {
-    return Consumer<ApplicationState>(
-        builder: (context, applicationState, child) => Consumer<LibraryState>(
-            builder: (context, libraryState, child) =>
-                Consumer<StudentSessionState>(
-                    builder: (context, studentSessionState, child) =>
-                        Consumer<OrganizerSessionState>(
-                            builder: (context, organizerSessionState, child) {
-                          bool isLessonsVisible =
-                              libraryState.isCourseSelected &&
-                                  applicationState.isLoggedIn;
-                          bool isManageVisible =
-                              _isCourseAdmin(applicationState, libraryState);
-                          bool isSessionsVisible =
-                              applicationState.isLoggedIn &&
-                                  (libraryState.isCourseSelected ||
-                                      studentSessionState.isInitialized ||
-                                      organizerSessionState.isInitialized);
-                          bool isProfileVisible = applicationState.isLoggedIn;
+    return Consumer4<ApplicationState, LibraryState, StudentSessionState,
+        OrganizerSessionState>(
+        builder: (context, applicationState, libraryState, studentSessionState,
+            organizerSessionState, child) {
+      bool isLessonsVisible =
+          libraryState.isCourseSelected && applicationState.isLoggedIn;
+      bool isManageVisible =
+          _isCourseAdmin(applicationState, libraryState);
+      bool isSessionsVisible = applicationState.isLoggedIn &&
+          (libraryState.isCourseSelected ||
+              studentSessionState.isInitialized ||
+              organizerSessionState.isInitialized);
+      bool isProfileVisible = applicationState.isLoggedIn;
 
-                          var currentIndex = _determineCurrentIndex(
-                              context,
-                              applicationState,
-                              libraryState,
-                              studentSessionState,
-                              organizerSessionState,
-                              isLessonsVisible,
-                              isManageVisible,
-                              isSessionsVisible,
-                              isProfileVisible);
+      var currentIndex = _determineCurrentIndex(
+          context,
+          applicationState,
+          libraryState,
+          studentSessionState,
+          organizerSessionState,
+          isLessonsVisible,
+          isManageVisible,
+          isSessionsVisible,
+          isProfileVisible);
 
-                          return BottomNavigationBar(
-                            items: [
-                              const BottomNavigationBarItem(
-                                icon: Icon(Icons.home),
-                                label: 'Home',
-                              ),
-                              if (isLessonsVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.list_alt_rounded),
-                                  label: 'Lessons',
-                                ),
-                              if (isManageVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.settings),
-                                  label: 'Manage',
-                                ),
-                              if (isSessionsVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.calendar_today),
-                                  label: 'Sessions',
-                                ),
-                              if (isProfileVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.person),
-                                  label: 'Profile',
-                                ),
-                            ],
-                            currentIndex: currentIndex == -1 ? 0 : currentIndex,
-                            onTap: (index) => _handleTap(
-                                index,
-                                context,
-                                applicationState,
-                                libraryState,
-                                studentSessionState,
-                                organizerSessionState,
-                                isLessonsVisible,
-                                isManageVisible,
-                                isSessionsVisible,
-                                isProfileVisible),
-                            selectedItemColor: currentIndex == -1
-                                ? Theme.of(context).hintColor
-                                : Theme.of(context).primaryColor,
-                            unselectedItemColor: Theme.of(context).hintColor,
-                          );
-                        }))));
+      return BottomNavigationBar(
+        items: [
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          if (isLessonsVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.list_alt_rounded),
+              label: 'Lessons',
+            ),
+          if (isManageVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.settings),
+              label: 'Manage',
+            ),
+          if (isSessionsVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_today),
+              label: 'Sessions',
+            ),
+          if (isProfileVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+        ],
+        currentIndex: currentIndex == -1 ? 0 : currentIndex,
+        onTap: (index) => _handleTap(
+            index,
+            context,
+            applicationState,
+            libraryState,
+            studentSessionState,
+            organizerSessionState,
+            isLessonsVisible,
+            isManageVisible,
+            isSessionsVisible,
+            isProfileVisible),
+        selectedItemColor:
+            currentIndex == -1 ? Theme.of(context).hintColor : Theme.of(context).primaryColor,
+        unselectedItemColor: Theme.of(context).hintColor,
+      );
+    });
   }
 
   static NavigationEnum _getSessionNavigationTarget(

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -99,17 +99,15 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<ApplicationState>(
-        builder: (context, applicationState, child) {
-      return Consumer<StudentState>(builder: (context, studentState, child) {
-        return Consumer<LibraryState>(builder: (context, libraryState, child) {
-          Lesson? lesson = _getLesson(libraryState, context);
-          int? levelPosition = _findLevelPosition(lesson, libraryState);
+    return Consumer3<ApplicationState, StudentState, LibraryState>(
+        builder: (context, applicationState, studentState, libraryState, child) {
+      Lesson? lesson = _getLesson(libraryState, context);
+      int? levelPosition = _findLevelPosition(lesson, libraryState);
 
-          if (lesson != null) {
-            var counts = studentState.getCountsForLesson(lesson);
+      if (lesson != null) {
+        var counts = studentState.getCountsForLesson(lesson);
 
-            return Scaffold(
+        return Scaffold(
                 appBar: AppBar(title: Text('Lesson: ${lesson.title}')),
                 bottomNavigationBar: BottomBarV2.build(context),
                 floatingActionButton: FloatingActionButton(
@@ -203,14 +201,12 @@ class LessonDetailState extends State<LessonDetailPage> {
                             ),
                           ),
                         ))));
-          }
+      }
 
-          return Scaffold(
-              appBar: AppBar(title: const Text('Nothing loaded')),
-              bottomNavigationBar: const BottomBar(),
-              body: const SizedBox.shrink());
-        });
-      });
+      return Scaffold(
+          appBar: AppBar(title: const Text('Nothing loaded')),
+          bottomNavigationBar: const BottomBar(),
+          body: const SizedBox.shrink());
     });
   }
 

--- a/lib/ui_foundation/level_list_page.dart
+++ b/lib/ui_foundation/level_list_page.dart
@@ -34,42 +34,40 @@ class LevelListState extends State<LevelListPage> {
           alignment: Alignment.topCenter,
           child: CustomUiConstants.framePage(
               enableCourseLoadingGuard: true,
-              Consumer<LibraryState>(
-                  builder: (context, libraryState, child) =>
-                      Consumer<StudentState>(
-                      builder: (context, studentState, child) {
-                    List<LevelCompletion> levelCompletions =
-                        studentState.getLevelCompletions(libraryState);
+              Consumer2<LibraryState, StudentState>(
+                  builder: (context, libraryState, studentState, child) {
+                List<LevelCompletion> levelCompletions =
+                    studentState.getLevelCompletions(libraryState);
 
-                    return SingleChildScrollView(
-                        child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        CustomUiConstants.getTextPadding(Text(
-                          '${libraryState.selectedCourse?.title} Curriculum',
-                          style: CustomTextStyles.headline,
-                        )),
-                        generateLevelList(levelCompletions, libraryState),
-                        CustomUiConstants.getTextPadding(Text(
-                          '\nStats',
-                          style: CustomTextStyles.headline,
-                        )),
-                        Text(
-                          'Lessons practiced: ${studentState.getPracticeCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        Text(
-                          'Lessons completed: ${studentState.getGraduationCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        Text(
-                          'Lessons taught: ${studentState.getTeachCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        CustomUiConstants.getGeneralFooter(context)
-                      ],
-                    ));
-                  }))),
+                return SingleChildScrollView(
+                    child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CustomUiConstants.getTextPadding(Text(
+                      '${libraryState.selectedCourse?.title} Curriculum',
+                      style: CustomTextStyles.headline,
+                    )),
+                    generateLevelList(levelCompletions, libraryState),
+                    CustomUiConstants.getTextPadding(Text(
+                      '\nStats',
+                      style: CustomTextStyles.headline,
+                    )),
+                    Text(
+                      'Lessons practiced: ${studentState.getPracticeCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    Text(
+                      'Lessons completed: ${studentState.getGraduationCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    Text(
+                      'Lessons taught: ${studentState.getTeachCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    CustomUiConstants.getGeneralFooter(context)
+                  ],
+                ));
+              })),
         ));
   }
 

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -41,34 +41,30 @@ class SessionStudentState extends State<SessionStudentPage> {
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,
-            child: CustomUiConstants.framePage(Consumer<ApplicationState>(
-                builder: (context, applicationState, child) {
-              return Consumer<LibraryState>(
-                  builder: (context, libraryState, child) {
-                return Consumer<StudentSessionState>(
-                    builder: (context, studentSessionState, child) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (studentSessionState.currentSession?.isActive == false)
-                        CustomUiConstants.getTextPadding(Text(
-                            'The session has ended!',
-                            style: CustomTextStyles.subHeadline)),
-                      Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: Align(
-                              alignment: Alignment.center,
-                              child: Text(
-                                'Session: ${studentSessionState.currentSession?.name ?? ''}',
-                                style: CustomTextStyles.headline,
-                                textAlign: TextAlign.center,
-                              ))),
-                      _createPairingTable2(
-                          studentSessionState, libraryState, applicationState),
-                    ],
-                  );
-                });
-              });
+            child: CustomUiConstants.framePage(
+                Consumer3<ApplicationState, LibraryState, StudentSessionState>(
+                    builder: (context, applicationState, libraryState,
+                        studentSessionState, child) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (studentSessionState.currentSession?.isActive == false)
+                    CustomUiConstants.getTextPadding(Text(
+                        'The session has ended!',
+                        style: CustomTextStyles.subHeadline)),
+                  Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Align(
+                          alignment: Alignment.center,
+                          child: Text(
+                            'Session: ${studentSessionState.currentSession?.name ?? ''}',
+                            style: CustomTextStyles.headline,
+                            textAlign: TextAlign.center,
+                          ))),
+                  _createPairingTable2(
+                      studentSessionState, libraryState, applicationState),
+                ],
+              );
             }))));
   }
 


### PR DESCRIPTION
## Summary
- simplify widget tree by replacing nested `Consumer` widgets with `Consumer2`/`Consumer3`/`Consumer4`
- streamline bottom navigation logic to read multiple state objects at once

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e56da3d9c832eba36b24838bd99bc