### PR TITLE
Move lesson comment operations into data helper

### DIFF
--- a/lib/data/data_helpers/lesson_comment_functions.dart
+++ b/lib/data/data_helpers/lesson_comment_functions.dart
@@ -1,0 +1,37 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/lesson.dart';
+import 'package:social_learning/data/lesson_comment.dart';
+import 'package:social_learning/data/user.dart';
+
+class LessonCommentFunctions {
+  static final FirebaseFirestore _firestore = FirestoreService.instance;
+
+  static Future<void> addLessonComment(
+      Lesson lesson, String comment, User user) async {
+    final userRef = docRef('users', user.id);
+    final lessonRef = docRef('lessons', lesson.id!);
+
+    await _firestore.collection('lessonComments').add({
+      'lessonId': lessonRef,
+      'text': comment,
+      'creatorId': userRef,
+      'creatorUid': user.uid,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    print('finished firebase call to create comment');
+  }
+
+  static Future<void> deleteLessonComment(LessonComment comment) async {
+    print('Deleting comment: ${comment.id}');
+    await _firestore
+        .doc('/lessonComments/${comment.id}')
+        .delete()
+        .onError((error, stackTrace) {
+      print('Failed to delete comment: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    });
+  }
+}

--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -12,7 +12,6 @@ import 'package:social_learning/data/Level.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
-import 'package:social_learning/data/lesson_comment.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:collection/collection.dart';
@@ -811,33 +810,6 @@ class LibraryState extends ChangeNotifier {
     }
   }
 
-  addLessonComment(Lesson lesson, String comment) async {
-    User user = _applicationState.currentUser!;
-    DocumentReference userId =
-        FirebaseFirestore.instance.doc('/users/${user.id}');
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
-
-    await FirebaseFirestore.instance.collection('lessonComments').add({
-      'lessonId': lessonId,
-      'text': comment,
-      'creatorId': userId,
-      'creatorUid': user.uid,
-      'createdAt': FieldValue.serverTimestamp(),
-    });
-    print('finished firebase call to create comment');
-  }
-
-  deleteLessonComment(LessonComment comment) async {
-    print('Deleting comment: ${comment.id}');
-    await FirebaseFirestore.instance
-        .doc('/lessonComments/${comment.id}')
-        .delete()
-        .onError((error, stackTrace) {
-      print('Failed to delete comment: $error');
-      debugPrintStack(stackTrace: stackTrace);
-    });
-  }
 
   Future<bool> doesCourseTitleExist(String title) async {
     return await FirebaseFirestore.instance

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/data/Level.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/lesson_comment.dart';
+import 'package:social_learning/data/data_helpers/lesson_comment_functions.dart';
 import 'package:social_learning/data/data_helpers/progress_video_functions.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/data_helpers/user_functions.dart';
@@ -176,8 +177,8 @@ class LessonDetailState extends State<LessonDetailPage> {
                                         ),
                                       ),
                                       /*),*/
-                                      _createCommentsView(lesson, context,
-                                          libraryState, applicationState),
+                                      _createCommentsView(
+                                          lesson, context, applicationState),
                                       SingleChildScrollView(
                                         child: Column(
                                           children: <Widget>[
@@ -448,8 +449,8 @@ class LessonDetailState extends State<LessonDetailPage> {
         });
   }
 
-  Widget _createCommentsView(Lesson lesson, BuildContext context,
-      LibraryState libraryState, ApplicationState applicationState) {
+  Widget _createCommentsView(
+      Lesson lesson, BuildContext context, ApplicationState applicationState) {
     DocumentReference lessonId = docRef('lessons', lesson.id!);
     print('Querying for comments for lesson: $lessonId');
     Widget commentColumn = StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
@@ -546,7 +547,7 @@ class LessonDetailState extends State<LessonDetailPage> {
                         if (isSelf)
                           IconButton(
                               onPressed: () {
-                                _deleteComment(comment, libraryState);
+                                _deleteComment(comment);
                               },
                               icon: Icon(Icons.close, color: Colors.grey)),
                       ])));
@@ -561,7 +562,7 @@ class LessonDetailState extends State<LessonDetailPage> {
       children: [
         Expanded(
             child: TextField(
-          onSubmitted: (_) => _sendComment(lesson, libraryState),
+          onSubmitted: (_) => _sendComment(lesson, applicationState),
           controller: _commentController,
           decoration: const InputDecoration(
               hintText: 'Leave a comment...',
@@ -569,7 +570,7 @@ class LessonDetailState extends State<LessonDetailPage> {
         )),
         IconButton(
             icon: const Icon(Icons.send),
-            onPressed: () => _sendComment(lesson, libraryState))
+            onPressed: () => _sendComment(lesson, applicationState))
       ],
     );
 
@@ -579,7 +580,7 @@ class LessonDetailState extends State<LessonDetailPage> {
     ]);
   }
 
-  void _sendComment(Lesson lesson, LibraryState libraryState) {
+  void _sendComment(Lesson lesson, ApplicationState applicationState) {
     // Send the comment
     print('send clicked');
     if (_commentController.text.isNotEmpty) {
@@ -587,7 +588,8 @@ class LessonDetailState extends State<LessonDetailPage> {
       _commentController.clear();
 
       print('attempting to create comment');
-      libraryState.addLessonComment(lesson, comment);
+      LessonCommentFunctions.addLessonComment(
+          lesson, comment, applicationState.currentUser!);
     }
   }
 
@@ -820,7 +822,7 @@ class LessonDetailState extends State<LessonDetailPage> {
     setState(() {});
   }
 
-  void _deleteComment(LessonComment comment, LibraryState libraryState) {
+  void _deleteComment(LessonComment comment) {
     // Show a dialog to confirm
     showDialog(
         context: context,
@@ -837,7 +839,7 @@ class LessonDetailState extends State<LessonDetailPage> {
                   child: const Text('Cancel')),
               ElevatedButton(
                   onPressed: () {
-                    libraryState.deleteLessonComment(comment);
+                    LessonCommentFunctions.deleteLessonComment(comment);
                     Navigator.pop(context);
                   },
                   child: const Text('Delete'))


### PR DESCRIPTION
## Summary
- add `LessonCommentFunctions` for Firestore comment helpers
- remove comment methods from `LibraryState`
- update lesson detail page to use `LessonCommentFunctions`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5c486fa8832eaf30985b7782b89d