### PR TITLE
test: expand course plan function coverage

### DIFF
--- a/test/course_plan_functions_test.dart
+++ b/test/course_plan_functions_test.dart
@@ -23,4 +23,44 @@ void main() {
     final plan = await CoursePlanFunctions.getCoursePlanById(id);
     expect(plan?.planJson, 'plan');
   });
+
+  test('getCoursePlanById returns null if missing', () async {
+    final plan = await CoursePlanFunctions.getCoursePlanById('missing');
+    expect(plan, isNull);
+  });
+
+  test('fetch by course reference', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final courseRef = fake.collection('courses').doc('c1');
+    final id =
+        await CoursePlanFunctions.createCoursePlan(courseRef, 'plan json');
+
+    final plan = await CoursePlanFunctions.getCoursePlanByCourse(courseRef);
+
+    expect(plan?.id, id);
+    expect(plan?.planJson, 'plan json');
+  });
+
+  test('updatePlanJson updates the stored plan', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final courseRef = fake.collection('courses').doc('c1');
+    final id =
+        await CoursePlanFunctions.createCoursePlan(courseRef, 'original');
+
+    await CoursePlanFunctions.updatePlanJson(id, 'updated');
+    final plan = await CoursePlanFunctions.getCoursePlanById(id);
+
+    expect(plan?.planJson, 'updated');
+  });
+
+  test('storeGeneratedJson saves generated output', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final courseRef = fake.collection('courses').doc('c1');
+    final id = await CoursePlanFunctions.createCoursePlan(courseRef, 'plan');
+
+    await CoursePlanFunctions.storeGeneratedJson(id, '{"levels": []}');
+    final plan = await CoursePlanFunctions.getCoursePlanById(id);
+
+    expect(plan?.generatedJson, '{"levels": []}');
+  });
 }


### PR DESCRIPTION
## Summary
- add tests for course plan retrieval, update, and generated-json storage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5d70f948832e9850c88b89089a41