### PR TITLE
refactor: simplify multi-provider consumers

### DIFF
--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -125,20 +125,17 @@ class CmsLessonState extends State<CmsLessonPage> {
                   children: [
                     CustomUiConstants.getTextPadding(Text('Create Lesson',
                         style: CustomTextStyles.headline)),
-                    Consumer<LibraryState>(
-                      builder: (context, libraryState, child) {
-                        return Consumer<ApplicationState>(
-                            builder: (context, applicationState, child) {
-                          return Column(
-                            children: [
-                              _createCoreCard(context),
-                              SizedBox(height: 8),
-                              _createGraduationRequirementsCard(context),
-                              SizedBox(height: 8),
-                              _createVideoCard(context)
-                            ],
-                          );
-                        });
+                    Consumer2<LibraryState, ApplicationState>(
+                      builder: (context, libraryState, applicationState, child) {
+                        return Column(
+                          children: [
+                            _createCoreCard(context),
+                            SizedBox(height: 8),
+                            _createGraduationRequirementsCard(context),
+                            SizedBox(height: 8),
+                            _createVideoCard(context)
+                          ],
+                        );
                       },
                     ),
                     Row(

--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -50,45 +50,39 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
           child: CustomUiConstants.framePage(
               enableCreatorGuard: true,
               enableCourseLoadingGuard: true,
-              Consumer<LibraryState>(
-                  builder: (context, libraryState, child) =>
-                      Consumer<StudentState>(
-                          builder: (context, studentState, child) {
-                        return OneTimeBanner(
-                            prefsKey: 'instructorDashboardHint',
-                            message:
-                                'Tap the chart icon above to open your Instructor Dashboard.',
-                            leading: Icon(Icons.bar_chart, color: Colors.blue),
-                            child: SingleChildScrollView(
-                                child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                CustomUiConstants.getTextPadding(Text(
-                                  '${libraryState.selectedCourse?.title} Curriculum',
-                                  style: CustomTextStyles.headline,
-                                )),
-                                if (libraryState
-                                        .selectedCourse?.invitationCode !=
-                                    null)
-                                  CustomUiConstants.getTextPadding(Text(
-                                      'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
-                                      style:
-                                          CustomTextStyles.getBody(context))),
-                                generateLevelList(context, libraryState),
-                                InkWell(
-                                    onTap: () {
-                                      _addLevel(context, libraryState);
-                                    },
-                                    child: Text('Add level',
-                                        style:
-                                            CustomTextStyles.getLinkNoUnderline(
-                                                context))),
-                                _generateUnattachedLessons(
-                                    context, libraryState),
-                                CustomUiConstants.getGeneralFooter(context)
-                              ],
-                            )));
-                      }))),
+                Consumer2<LibraryState, StudentState>(
+                    builder: (context, libraryState, studentState, child) {
+                  return OneTimeBanner(
+                      prefsKey: 'instructorDashboardHint',
+                      message:
+                          'Tap the chart icon above to open your Instructor Dashboard.',
+                      leading: Icon(Icons.bar_chart, color: Colors.blue),
+                      child: SingleChildScrollView(
+                          child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          CustomUiConstants.getTextPadding(Text(
+                            '${libraryState.selectedCourse?.title} Curriculum',
+                            style: CustomTextStyles.headline,
+                          )),
+                          if (libraryState.selectedCourse?.invitationCode !=
+                              null)
+                            CustomUiConstants.getTextPadding(Text(
+                                'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
+                                style: CustomTextStyles.getBody(context))),
+                          generateLevelList(context, libraryState),
+                          InkWell(
+                              onTap: () {
+                                _addLevel(context, libraryState);
+                              },
+                              child: Text('Add level',
+                                  style: CustomTextStyles.getLinkNoUnderline(
+                                      context))),
+                          _generateUnattachedLessons(context, libraryState),
+                          CustomUiConstants.getGeneralFooter(context)
+                        ],
+                      )));
+                })),
         ));
   }
 

--- a/lib/ui_foundation/course_create_page.dart
+++ b/lib/ui_foundation/course_create_page.dart
@@ -65,37 +65,35 @@ class CourseCreateState extends State<CourseCreatePage> {
             child: CustomUiConstants.framePage(Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Consumer<LibraryState>(
-                  builder: (context, libraryState, child) {
-                    return Consumer<ApplicationState>(
-                        builder: (context, applicationState, child) {
-                      return Card(
-                          margin: const EdgeInsets.all(8.0),
-                          child: Column(children: [
-                            Container(
-                                width: double.infinity,
-                                padding: const EdgeInsets.all(8.0),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).primaryColor,
-                                  borderRadius: const BorderRadius.only(
-                                    topLeft: Radius.circular(16.0),
-                                    topRight: Radius.circular(16.0),
-                                  ),
+                Consumer2<LibraryState, ApplicationState>(
+                  builder: (context, libraryState, applicationState, child) {
+                    return Card(
+                        margin: const EdgeInsets.all(8.0),
+                        child: Column(children: [
+                          Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.all(8.0),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).primaryColor,
+                                borderRadius: const BorderRadius.only(
+                                  topLeft: Radius.circular(16.0),
+                                  topRight: Radius.circular(16.0),
                                 ),
-                                child: Text('Create Course',
-                                    style: CustomTextStyles.headline)),
-                            SizedBox(height: 8),
-                            Padding(
-                                padding: EdgeInsets.all(8),
-                                child: Column(children: [
-                                  TextField(
-                                      decoration:
-                                          CustomUiConstants.getFilledInputDecoration(
-                                        context,
-                                        labelText: 'Course Name',
-                                      ).copyWith(errorText: courseNameError),
-                                      controller: courseNameController),
-                                  SizedBox(height: 8),
+                              ),
+                              child: Text('Create Course',
+                                  style: CustomTextStyles.headline)),
+                          SizedBox(height: 8),
+                          Padding(
+                              padding: EdgeInsets.all(8),
+                              child: Column(children: [
+                                TextField(
+                                    decoration:
+                                        CustomUiConstants.getFilledInputDecoration(
+                                      context,
+                                      labelText: 'Course Name',
+                                    ).copyWith(errorText: courseNameError),
+                                    controller: courseNameController),
+                                SizedBox(height: 8),
                                   TextField(
                                       decoration:
                                           CustomUiConstants.getFilledInputDecoration(

--- a/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
+++ b/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
@@ -20,12 +20,10 @@ class AutoSignInWidgetState extends State<AutoSignInWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<ApplicationState>(
-        builder: (context, applicationState, child) {
-      return Consumer<LibraryState>(builder: (context, libraryState, child) {
-        maybeRedirect(applicationState, libraryState);
-        return SizedBox.shrink();
-      });
+    return Consumer2<ApplicationState, LibraryState>(
+        builder: (context, applicationState, libraryState, child) {
+      maybeRedirect(applicationState, libraryState);
+      return SizedBox.shrink();
     });
   }
 

--- a/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
+++ b/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
@@ -9,81 +9,76 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 
 class BottomBarV2 {
   static Widget build(BuildContext context) {
-    return Consumer<ApplicationState>(
-        builder: (context, applicationState, child) => Consumer<LibraryState>(
-            builder: (context, libraryState, child) =>
-                Consumer<StudentSessionState>(
-                    builder: (context, studentSessionState, child) =>
-                        Consumer<OrganizerSessionState>(
-                            builder: (context, organizerSessionState, child) {
-                          bool isLessonsVisible =
-                              libraryState.isCourseSelected &&
-                                  applicationState.isLoggedIn;
-                          bool isManageVisible =
-                              _isCourseAdmin(applicationState, libraryState);
-                          bool isSessionsVisible =
-                              applicationState.isLoggedIn &&
-                                  (libraryState.isCourseSelected ||
-                                      studentSessionState.isInitialized ||
-                                      organizerSessionState.isInitialized);
-                          bool isProfileVisible = applicationState.isLoggedIn;
+    return Consumer4<ApplicationState, LibraryState, StudentSessionState,
+        OrganizerSessionState>(
+        builder: (context, applicationState, libraryState, studentSessionState,
+            organizerSessionState, child) {
+      bool isLessonsVisible =
+          libraryState.isCourseSelected && applicationState.isLoggedIn;
+      bool isManageVisible =
+          _isCourseAdmin(applicationState, libraryState);
+      bool isSessionsVisible = applicationState.isLoggedIn &&
+          (libraryState.isCourseSelected ||
+              studentSessionState.isInitialized ||
+              organizerSessionState.isInitialized);
+      bool isProfileVisible = applicationState.isLoggedIn;
 
-                          var currentIndex = _determineCurrentIndex(
-                              context,
-                              applicationState,
-                              libraryState,
-                              studentSessionState,
-                              organizerSessionState,
-                              isLessonsVisible,
-                              isManageVisible,
-                              isSessionsVisible,
-                              isProfileVisible);
+      var currentIndex = _determineCurrentIndex(
+          context,
+          applicationState,
+          libraryState,
+          studentSessionState,
+          organizerSessionState,
+          isLessonsVisible,
+          isManageVisible,
+          isSessionsVisible,
+          isProfileVisible);
 
-                          return BottomNavigationBar(
-                            items: [
-                              const BottomNavigationBarItem(
-                                icon: Icon(Icons.home),
-                                label: 'Home',
-                              ),
-                              if (isLessonsVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.list_alt_rounded),
-                                  label: 'Lessons',
-                                ),
-                              if (isManageVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.settings),
-                                  label: 'Manage',
-                                ),
-                              if (isSessionsVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.calendar_today),
-                                  label: 'Sessions',
-                                ),
-                              if (isProfileVisible)
-                                const BottomNavigationBarItem(
-                                  icon: Icon(Icons.person),
-                                  label: 'Profile',
-                                ),
-                            ],
-                            currentIndex: currentIndex == -1 ? 0 : currentIndex,
-                            onTap: (index) => _handleTap(
-                                index,
-                                context,
-                                applicationState,
-                                libraryState,
-                                studentSessionState,
-                                organizerSessionState,
-                                isLessonsVisible,
-                                isManageVisible,
-                                isSessionsVisible,
-                                isProfileVisible),
-                            selectedItemColor: currentIndex == -1
-                                ? Theme.of(context).hintColor
-                                : Theme.of(context).primaryColor,
-                            unselectedItemColor: Theme.of(context).hintColor,
-                          );
-                        }))));
+      return BottomNavigationBar(
+        items: [
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          if (isLessonsVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.list_alt_rounded),
+              label: 'Lessons',
+            ),
+          if (isManageVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.settings),
+              label: 'Manage',
+            ),
+          if (isSessionsVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_today),
+              label: 'Sessions',
+            ),
+          if (isProfileVisible)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+        ],
+        currentIndex: currentIndex == -1 ? 0 : currentIndex,
+        onTap: (index) => _handleTap(
+            index,
+            context,
+            applicationState,
+            libraryState,
+            studentSessionState,
+            organizerSessionState,
+            isLessonsVisible,
+            isManageVisible,
+            isSessionsVisible,
+            isProfileVisible),
+        selectedItemColor: currentIndex == -1
+            ? Theme.of(context).hintColor
+            : Theme.of(context).primaryColor,
+        unselectedItemColor: Theme.of(context).hintColor,
+      );
+    });
   }
 
   static NavigationEnum _getSessionNavigationTarget(
@@ -135,7 +130,7 @@ class BottomBarV2 {
     String? currentRoute = ModalRoute.of(context)?.settings.name;
 
     if (currentRoute == null) {
-      print('Couldn\'t determine the current route.');
+      print('Couldn't determine the current route.');
       return -1;
     }
 
@@ -186,7 +181,7 @@ class BottomBarV2 {
           (isManageVisible ? 1 : 0) +
           (isSessionsVisible ? 1 : 0);
     } else {
-      print('Unknown route: $currentRoute');
+      print('Unknown route: ${currentRoute}');
       return -1;
     }
   }
@@ -284,6 +279,6 @@ class BottomBarV2 {
       }
     }
 
-    print('Unknown index: $originalIndex');
+    print('Unknown index: ${originalIndex}');
   }
 }

--- a/lib/ui_foundation/home_page.dart
+++ b/lib/ui_foundation/home_page.dart
@@ -107,15 +107,13 @@ class HomePageState extends State<HomePage> {
                 style:
                     CustomTextStyles.subHeadline.copyWith(color: Colors.white)),
           ),
-          Consumer<LibraryState>(builder: (context, libraryState, child) {
-            return Consumer<ApplicationState>(
-                builder: (context, applicationState, child) {
-              return Column(
-                  children: libraryState.availableCourses
-                      .map((course) => _createCourseWidget(
-                          course, libraryState, applicationState))
-                      .toList());
-            });
+          Consumer2<LibraryState, ApplicationState>(
+              builder: (context, libraryState, applicationState, child) {
+            return Column(
+                children: libraryState.availableCourses
+                    .map((course) => _createCourseWidget(
+                        course, libraryState, applicationState))
+                    .toList());
           }),
         ],
       ),

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -98,15 +98,13 @@ class LessonDetailState extends State<LessonDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<ApplicationState>(
-        builder: (context, applicationState, child) {
-      return Consumer<StudentState>(builder: (context, studentState, child) {
-        return Consumer<LibraryState>(builder: (context, libraryState, child) {
-          Lesson? lesson = _getLesson(libraryState, context);
-          int? levelPosition = _findLevelPosition(lesson, libraryState);
+    return Consumer3<ApplicationState, StudentState, LibraryState>(
+        builder: (context, applicationState, studentState, libraryState, child) {
+      Lesson? lesson = _getLesson(libraryState, context);
+      int? levelPosition = _findLevelPosition(lesson, libraryState);
 
-          if (lesson != null) {
-            var counts = studentState.getCountsForLesson(lesson);
+      if (lesson != null) {
+        var counts = studentState.getCountsForLesson(lesson);
 
             return Scaffold(
                 appBar: AppBar(title: Text('Lesson: ${lesson.title}')),
@@ -204,14 +202,12 @@ class LessonDetailState extends State<LessonDetailPage> {
                         ))));
           }
 
-          return Scaffold(
-              appBar: AppBar(title: const Text('Nothing loaded')),
-              bottomNavigationBar: BottomBarV2.build(context),
-              body: const SizedBox.shrink());
-        });
+        return Scaffold(
+            appBar: AppBar(title: const Text('Nothing loaded')),
+            bottomNavigationBar: BottomBarV2.build(context),
+            body: const SizedBox.shrink());
       });
-    });
-  }
+    }
 
   int? _findLevelPosition(Lesson? lesson, LibraryState libraryState) {
     var levelId = lesson?.levelId;

--- a/lib/ui_foundation/level_detail_page.dart
+++ b/lib/ui_foundation/level_detail_page.dart
@@ -56,27 +56,25 @@ class LevelDetailState extends State<LevelDetailPage> {
           alignment: Alignment.topCenter,
           child: CustomUiConstants.framePage(
               enableCourseLoadingGuard: true,
-              Consumer<LibraryState>(
-                  builder: (context, libraryState, child) =>
-                      Consumer<StudentState>(
-                      builder: (context, studentState, child) {
-                    LevelDetailArgument? argument = ModalRoute.of(context)!
-                        .settings
-                        .arguments as LevelDetailArgument?;
-                    var levelId = argument?.levelId;
-                    var isFlexLessons = argument?.isFlexLessons;
-                    if ((levelId == null) && (isFlexLessons != true)) {
-                      return const Text('Failed to load (1).');
-                    }
+              Consumer2<LibraryState, StudentState>(
+                  builder: (context, libraryState, studentState, child) {
+                LevelDetailArgument? argument = ModalRoute.of(context)!
+                    .settings
+                    .arguments as LevelDetailArgument?;
+                var levelId = argument?.levelId;
+                var isFlexLessons = argument?.isFlexLessons;
+                if ((levelId == null) && (isFlexLessons != true)) {
+                  return const Text('Failed to load (1).');
+                }
 
-                    if (isFlexLessons == true) {
-                      return _generateFlexLessonView(
-                          libraryState, studentState);
-                    } else {
-                      return _generateRegularLessonView(
-                          levelId!, libraryState, studentState);
-                    }
-                  }))),
+                if (isFlexLessons == true) {
+                  return _generateFlexLessonView(
+                      libraryState, studentState);
+                } else {
+                  return _generateRegularLessonView(
+                      levelId!, libraryState, studentState);
+                }
+              })),
         ));
   }
 

--- a/lib/ui_foundation/level_list_page.dart
+++ b/lib/ui_foundation/level_list_page.dart
@@ -34,42 +34,40 @@ class LevelListState extends State<LevelListPage> {
           alignment: Alignment.topCenter,
           child: CustomUiConstants.framePage(
               enableCourseLoadingGuard: true,
-              Consumer<LibraryState>(
-                  builder: (context, libraryState, child) =>
-                      Consumer<StudentState>(
-                      builder: (context, studentState, child) {
-                    List<LevelCompletion> levelCompletions =
-                        studentState.getLevelCompletions(libraryState);
+              Consumer2<LibraryState, StudentState>(
+                  builder: (context, libraryState, studentState, child) {
+                List<LevelCompletion> levelCompletions =
+                    studentState.getLevelCompletions(libraryState);
 
-                    return SingleChildScrollView(
-                        child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        CustomUiConstants.getTextPadding(Text(
-                          '${libraryState.selectedCourse?.title} Curriculum',
-                          style: CustomTextStyles.headline,
-                        )),
-                        generateLevelList(levelCompletions, libraryState),
-                        CustomUiConstants.getTextPadding(Text(
-                          '\nStats',
-                          style: CustomTextStyles.headline,
-                        )),
-                        Text(
-                          'Lessons practiced: ${studentState.getPracticeCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        Text(
-                          'Lessons completed: ${studentState.getGraduationCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        Text(
-                          'Lessons taught: ${studentState.getTeachCount()}',
-                          style: CustomTextStyles.getBody(context),
-                        ),
-                        CustomUiConstants.getGeneralFooter(context)
-                      ],
-                    ));
-                  }))),
+                return SingleChildScrollView(
+                    child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CustomUiConstants.getTextPadding(Text(
+                      '${libraryState.selectedCourse?.title} Curriculum',
+                      style: CustomTextStyles.headline,
+                    )),
+                    generateLevelList(levelCompletions, libraryState),
+                    CustomUiConstants.getTextPadding(Text(
+                      '\nStats',
+                      style: CustomTextStyles.headline,
+                    )),
+                    Text(
+                      'Lessons practiced: ${studentState.getPracticeCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    Text(
+                      'Lessons completed: ${studentState.getGraduationCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    Text(
+                      'Lessons taught: ${studentState.getTeachCount()}',
+                      style: CustomTextStyles.getBody(context),
+                    ),
+                    CustomUiConstants.getGeneralFooter(context)
+                  ],
+                ));
+              })),
         ));
   }
 

--- a/lib/ui_foundation/online_session_review_page.dart
+++ b/lib/ui_foundation/online_session_review_page.dart
@@ -161,11 +161,9 @@ class OnlineSessionReviewPageState extends State<OnlineSessionReviewPage> {
         alignment: Alignment.topCenter,
         child: CustomUiConstants.framePage(
           SingleChildScrollView(
-            child: Consumer<OnlineSessionState>(
-                builder: (context, onlineSessionState, child) {
+            child: Consumer2<OnlineSessionState, LibraryState>(
+                builder: (context, onlineSessionState, libraryState, child) {
               // Get the pending review from the state.
-              OnlineSessionState onlineSessionState =
-                  Provider.of<OnlineSessionState>(context, listen: false);
               OnlineSessionReview? pendingReview =
                   onlineSessionState.pendingReview;
               if (pendingReview == null) {
@@ -184,15 +182,13 @@ class OnlineSessionReviewPageState extends State<OnlineSessionReviewPage> {
                       return const Center(child: CircularProgressIndicator());
                     }
                     User otherUser = userSnapshot.data!;
-                    return Consumer<LibraryState>(
-                        builder: (context, libraryState, child) {
-                      Lesson? lesson =
-                          libraryState.findLesson(_review.lessonId.id);
-                      if (lesson == null) {
-                        return const Center(child: CircularProgressIndicator());
-                      }
+                    Lesson? lesson =
+                        libraryState.findLesson(_review.lessonId.id);
+                    if (lesson == null) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
 
-                      return Column(
+                    return Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Card(

--- a/lib/ui_foundation/online_session_waiting_room_page.dart
+++ b/lib/ui_foundation/online_session_waiting_room_page.dart
@@ -41,49 +41,44 @@ class OnlineSessionWaitingRoomState
             bottomNavigationBar: BottomBarV2.build(context),
             body: Align(
               alignment: Alignment.topCenter,
-              child: CustomUiConstants.framePage(
+                child: CustomUiConstants.framePage(
                 enableScrolling: false,
-                Consumer<ApplicationState>(
-                    builder: (context, applicationState, child) {
-                  return Consumer<OnlineSessionState>(
-                      builder: (context, onlineSessionState, child) {
-                    String? sessionId = onlineSessionState.waitingSession?.id;
-                    if (sessionId == null) {
-                      return Center(child: CircularProgressIndicator());
-                    } else {
-                      return StreamBuilder<
-                              DocumentSnapshot<Map<String, dynamic>>>(
-                          stream: OnlineSessionFunctions.getSessionStream(
-                              sessionId),
-                          builder: (context, snapshot) {
-                            if (!snapshot.hasData) {
-                              return Center(child: CircularProgressIndicator());
-                            }
+                Consumer2<ApplicationState, OnlineSessionState>(
+                    builder: (context, applicationState, onlineSessionState, child) {
+                  String? sessionId = onlineSessionState.waitingSession?.id;
+                  if (sessionId == null) {
+                    return Center(child: CircularProgressIndicator());
+                  } else {
+                    return StreamBuilder<
+                            DocumentSnapshot<Map<String, dynamic>>>(
+                        stream: OnlineSessionFunctions.getSessionStream(
+                            sessionId),
+                        builder: (context, snapshot) {
+                          if (!snapshot.hasData) {
+                            return Center(child: CircularProgressIndicator());
+                          }
 
-                            // Session no longer exists, so navigate away.
-                            if (!snapshot.data!.exists) {
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                Navigator.pushNamed(
-                                    context, NavigationEnum.sessionHome.route);
-                              });
-                              return Container();
-                            }
+                          // Session no longer exists, so navigate away.
+                          if (!snapshot.data!.exists) {
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              Navigator.pushNamed(
+                                  context, NavigationEnum.sessionHome.route);
+                            });
+                            return Container();
+                          }
 
-                            // The session has become active, redirect to the active session page.
-                            OnlineSession session =
-                                OnlineSession.fromSnapshot(snapshot.data!);
-                            if (session.status == OnlineSessionStatus.active) {
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                OnlineSessionState onlineSessionState =
-                                    Provider.of<OnlineSessionState>(context,
-                                        listen: false);
-                                onlineSessionState.setActiveSession(session);
+                          // The session has become active, redirect to the active session page.
+                          OnlineSession session =
+                              OnlineSession.fromSnapshot(snapshot.data!);
+                          if (session.status == OnlineSessionStatus.active) {
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              onlineSessionState.setActiveSession(session);
 
-                                Navigator.pushNamed(context,
-                                    NavigationEnum.onlineSessionActive.route);
-                              });
-                              return Container();
-                            }
+                              Navigator.pushNamed(context,
+                                  NavigationEnum.onlineSessionActive.route);
+                            });
+                            return Container();
+                          }
 
                             String sessionTypeText = session.isMentorInitiated
                                 ? 'Teaching'

--- a/lib/ui_foundation/profile_comparison_page.dart
+++ b/lib/ui_foundation/profile_comparison_page.dart
@@ -76,24 +76,23 @@ class ProfileComparisonState extends State<ProfileComparisonPage> {
             alignment: Alignment.topCenter,
             child: CustomUiConstants.framePage(
                 enableCourseLoadingGuard: true,
-                Consumer<ApplicationState>(
-              builder: (context, applicationState, child) {
-                return Consumer<LibraryState>(
-                    builder: (context, libraryState, child) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _createHeaderWidget(applicationState, libraryState),
-                      _createComparisonTable(context, libraryState)
-                    ],
-                  );
-                });
+                Consumer3<ApplicationState, LibraryState, StudentState>(
+              builder: (context, applicationState, libraryState, studentState, child) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _createHeaderWidget(applicationState, libraryState),
+                    _createComparisonTable(
+                        context, applicationState, libraryState, studentState)
+                  ],
+                );
               },
             ))));
   }
 
-  Widget _createComparisonTable(
-      BuildContext context, LibraryState libraryState) {
+  Widget _createComparisonTable(BuildContext context,
+      ApplicationState applicationState, LibraryState libraryState,
+      StudentState studentState) {
     if (_otherUser == null) {
       return const CircularProgressIndicator();
     }
@@ -121,29 +120,20 @@ class ProfileComparisonState extends State<ProfileComparisonPage> {
               .map((practiceRecord) => practiceRecord.lessonId.id)
               .toSet();
 
-          return Consumer<StudentState>(
-              builder: (context, studentState, child) {
-            ApplicationState applicationState =
-                Provider.of<ApplicationState>(context, listen: false);
+          Iterable<String> currentUserGraduatedLessonIds =
+              studentState.getGraduatedLessonIds();
 
-            Iterable<String> currentUserGraduatedLessonIds =
-                studentState.getGraduatedLessonIds();
+          currentUserGraduatedLessonIds = _handleAdminCase(
+              applicationState.currentUser,
+              currentUserGraduatedLessonIds,
+              context,
+              libraryState);
+          otherUserGraduatedLessonIds = _handleAdminCase(
+                  _otherUser, otherUserGraduatedLessonIds, context, libraryState)
+              .toSet();
 
-            currentUserGraduatedLessonIds = _handleAdminCase(
-                applicationState.currentUser,
-                currentUserGraduatedLessonIds,
-                context,
-                libraryState);
-            otherUserGraduatedLessonIds = _handleAdminCase(_otherUser,
-                    otherUserGraduatedLessonIds, context, libraryState)
-                .toSet();
-
-            return ProfileComparisonTable(
-                _otherUser,
-                currentUserGraduatedLessonIds,
-                otherUserGraduatedLessonIds,
-                libraryState);
-          });
+          return ProfileComparisonTable(_otherUser, currentUserGraduatedLessonIds,
+              otherUserGraduatedLessonIds, libraryState);
         });
   }
 

--- a/lib/ui_foundation/session_create_page.dart
+++ b/lib/ui_foundation/session_create_page.dart
@@ -36,10 +36,8 @@ class SessionCreateState extends State<SessionCreatePage> {
           children: [
             CustomUiConstants.getTextPadding(
                 Text('Create Session', style: CustomTextStyles.headline)),
-            Consumer<LibraryState>(
-              builder: (context, libraryState, child) {
-                return Consumer<ApplicationState>(
-                    builder: (context, applicationState, child) {
+              Consumer2<LibraryState, ApplicationState>(
+                builder: (context, libraryState, applicationState, child) {
                   return Table(columnWidths: const <int, TableColumnWidth>{
                     0: IntrinsicColumnWidth(),
                     1: FlexColumnWidth(),
@@ -60,7 +58,7 @@ class SessionCreateState extends State<SessionCreatePage> {
                       CustomUiConstants.getTextPadding(
                           Text('${libraryState.selectedCourse?.title}')),
                     ]),
-                  ]);
+                    ]);
                   // return GridView.count(
                   //   crossAxisCount: 2, shrinkWrap: true,
                   //   children: [
@@ -75,9 +73,8 @@ class SessionCreateState extends State<SessionCreatePage> {
                   //     Text('${libraryState.selectedCourse?.title}'),
                   //   ],
                   // );
-                });
-              },
-            ),
+                },
+              ),
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [

--- a/lib/ui_foundation/session_host_page.dart
+++ b/lib/ui_foundation/session_host_page.dart
@@ -51,31 +51,28 @@ class SessionHostState extends State<SessionHostPage> {
             alignment: Alignment.topCenter,
             child: CustomUiConstants.framePage(
                 enableCourseLoadingGuard: true,
-                Consumer<OrganizerSessionState>(
-                    builder: (context, organizerSessionState, child) {
-              return Consumer<LibraryState>(
-                  builder: (context, libraryState, child) {
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    CustomUiConstants.getTextPadding(Text(
-                        'Host Session: ${organizerSessionState.currentSession?.name}',
-                        style: CustomTextStyles.headline)),
-                    CustomUiConstants.getTextPadding(Text(
-                        '${organizerSessionState.currentSession?.participantCount} Participants',
-                        style: CustomTextStyles.subHeadline)),
-                    _createParticipantTable(
-                        organizerSessionState, libraryState),
-                    // Align(
-                    //     alignment: Alignment.centerRight,
-                    //     child: TextButton(
-                    //         onPressed: () =>
-                    //             SessionPairingAlgorithmTest().testAll(),
-                    //         child: const Text('Test'))),
-                    _createPairingTable(organizerSessionState, libraryState),
-                  ],
-                );
-              });
+                Consumer2<OrganizerSessionState, LibraryState>(
+                    builder: (context, organizerSessionState, libraryState, child) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CustomUiConstants.getTextPadding(Text(
+                      'Host Session: ${organizerSessionState.currentSession?.name}',
+                      style: CustomTextStyles.headline)),
+                  CustomUiConstants.getTextPadding(Text(
+                      '${organizerSessionState.currentSession?.participantCount} Participants',
+                      style: CustomTextStyles.subHeadline)),
+                  _createParticipantTable(
+                      organizerSessionState, libraryState),
+                  // Align(
+                  //     alignment: Alignment.centerRight,
+                  //     child: TextButton(
+                  //         onPressed: () =>
+                  //             SessionPairingAlgorithmTest().testAll(),
+                  //         child: const Text('Test'))),
+                  _createPairingTable(organizerSessionState, libraryState),
+                ],
+              );
             }))));
   }
 

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -41,35 +41,31 @@ class SessionStudentState extends State<SessionStudentPage> {
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,
-            child: CustomUiConstants.framePage(Consumer<ApplicationState>(
-                builder: (context, applicationState, child) {
-              return Consumer<LibraryState>(
-                  builder: (context, libraryState, child) {
-                return Consumer<StudentSessionState>(
-                    builder: (context, studentSessionState, child) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (studentSessionState.currentSession?.isActive == false)
-                        CustomUiConstants.getTextPadding(Text(
-                            'The session has ended!',
-                            style: CustomTextStyles.subHeadline)),
-                      Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: Align(
-                              alignment: Alignment.center,
-                              child: Text(
-                                'Session: ${studentSessionState.currentSession?.name ?? ''}',
-                                style: CustomTextStyles.headline,
-                                textAlign: TextAlign.center,
-                              ))),
-                      _createPairingTable2(
-                          studentSessionState, libraryState, applicationState),
-                    ],
-                  );
-                });
-              });
-            }))));
+            child: CustomUiConstants.framePage(
+                Consumer3<ApplicationState, LibraryState, StudentSessionState>(
+                    builder: (context, applicationState, libraryState,
+                        studentSessionState, child) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (studentSessionState.currentSession?.isActive == false)
+                    CustomUiConstants.getTextPadding(Text(
+                        'The session has ended!',
+                        style: CustomTextStyles.subHeadline)),
+                  Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Align(
+                          alignment: Alignment.center,
+                          child: Text(
+                            'Session: ${studentSessionState.currentSession?.name ?? ''}',
+                            style: CustomTextStyles.headline,
+                            textAlign: TextAlign.center,
+                          ))),
+                  _createPairingTable2(
+                      studentSessionState, libraryState, applicationState),
+                ],
+              );
+            })))));
   }
 
   Widget _createPairingTable2(StudentSessionState studentSessionState,


### PR DESCRIPTION
## Summary
- streamline provider usage by replacing nested Consumers with Consumer2+/3+/4
- centralize multi-state lookups in widgets like BottomBarV2 and lesson/session pages

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e5e650b3c832ebd0215b648b3867a