### PR TITLE
test: expand belt color coverage

### DIFF
--- a/test/belt_color_functions_test.dart
+++ b/test/belt_color_functions_test.dart
@@ -20,4 +20,34 @@ void main() {
     final color = BeltColorFunctions.getBeltColor(0);
     expect(color, BeltColorFunctions.colors.first);
   });
+
+  test('getBeltColor returns black for full proficiency', () {
+    final color = BeltColorFunctions.getBeltColor(1);
+    expect(color, BeltColorFunctions.colors.last);
+  });
+
+  test('getBeltColor returns purple for half proficiency', () {
+    final color = BeltColorFunctions.getBeltColor(0.5);
+    expect(color, BeltColorFunctions.colors[4]);
+  });
+
+  test('getBeltColor throws ArgumentError when proficiency below zero', () {
+    expect(() => BeltColorFunctions.getBeltColor(-0.1), throwsArgumentError);
+  });
+
+  test('getBeltColor throws ArgumentError when proficiency above one', () {
+    expect(() => BeltColorFunctions.getBeltColor(1.1), throwsArgumentError);
+  });
+
+  test('getBeltColor interpolates between adjacent colors for non integer proficiency', () {
+    final color = BeltColorFunctions.getBeltColor(0.33);
+    final colorIndex =
+        (BeltColorFunctions.colors.length - 1) * 0.33;
+    final lowerIndex = colorIndex.floor();
+    final upperIndex = colorIndex.ceil();
+    final lowerColor = BeltColorFunctions.colors[lowerIndex];
+    final upperColor = BeltColorFunctions.colors[upperIndex];
+    expect(color, isNot(equals(lowerColor)));
+    expect(color, isNot(equals(upperColor)));
+  });
 }


### PR DESCRIPTION
## Summary
- add tests for full and half proficiency belt colors
- assert invalid proficiency values throw errors
- verify interpolation between adjacent belt colors

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5d6c28fc832eb8cd87f24bc351ab