### PR TITLE
test: expand tag helper tests

### DIFF
--- a/test/teachable_item_tag_functions_test.dart
+++ b/test/teachable_item_tag_functions_test.dart
@@ -21,4 +21,61 @@ void main() {
     final tag = await TeachableItemTagFunctions.addTag(courseId: 'c1', name: 't', color: 'blue');
     expect(tag?.name, 't');
   });
+
+  test('updateTag updates name and color', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final tag = await TeachableItemTagFunctions.addTag(
+        courseId: 'c1', name: 'old', color: 'red');
+
+    await TeachableItemTagFunctions.updateTag(
+        tagId: tag!.id!, name: 'new', color: 'blue');
+
+    final snapshot =
+        await fake.collection('teachableItemTags').doc(tag.id!).get();
+    expect(snapshot.data()!['name'], 'new');
+    expect(snapshot.data()!['color'], 'blue');
+  });
+
+  test('deleteTag removes tag and its references from items', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final tag = await TeachableItemTagFunctions.addTag(
+        courseId: 'c1', name: 'tag', color: 'red');
+
+    final tagRef = fake.collection('teachableItemTags').doc(tag!.id!);
+    await fake.collection('teachableItems').doc('i1').set({
+      'tagIds': [tagRef],
+    });
+
+    await TeachableItemTagFunctions.deleteTag(tagId: tag.id!);
+
+    final tagSnapshot =
+        await fake.collection('teachableItemTags').doc(tag.id!).get();
+    expect(tagSnapshot.exists, false);
+
+    final itemSnapshot =
+        await fake.collection('teachableItems').doc('i1').get();
+    final tagIds = itemSnapshot.data()!['tagIds'] as List;
+    expect(tagIds, isEmpty);
+  });
+
+  test('getTagsForCourse returns tags in alphabetical order', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    await fake.collection('courses').doc('c2').set({'title': 'x'});
+
+    await TeachableItemTagFunctions.addTag(
+        courseId: 'c1', name: 'beta', color: 'blue');
+    await TeachableItemTagFunctions.addTag(
+        courseId: 'c1', name: 'alpha', color: 'red');
+    await TeachableItemTagFunctions.addTag(
+        courseId: 'c2', name: 'gamma', color: 'green');
+
+    final tags = await TeachableItemTagFunctions.getTagsForCourse('c1');
+    expect(tags.map((t) => t.name).toList(), ['alpha', 'beta']);
+  });
+
+  test('getTagsForCourse returns empty list when course has no tags', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final tags = await TeachableItemTagFunctions.getTagsForCourse('c1');
+    expect(tags, isEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- add coverage for updating teachable item tags
- ensure deleting a tag cleans up teachable item references
- verify `getTagsForCourse` ordering and empty-course behavior

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5db9d1a4832eb23ac6c741654685