### PR TITLE
test: expand teachable item coverage

### DIFF
--- a/test/teachable_item_functions_test.dart
+++ b/test/teachable_item_functions_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/teachable_item.dart';
+import 'package:social_learning/data/teachable_item_inclusion_status.dart';
 
 void main() {
   late FakeFirebaseFirestore fake;
@@ -22,5 +24,197 @@ void main() {
     final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
     final item = await TeachableItemFunctions.addItem(courseId: 'c1', categoryId: cat!.id!, name: 'item');
     expect(item?.name, 'item');
+  });
+
+  test('bulkCreateItems inserts multiple items', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final catRef = fake.collection('teachableItemCategories').doc('cat1');
+    await catRef.set({
+      'courseId': fake.collection('courses').doc('c1'),
+      'name': 'cat',
+      'sortOrder': 0,
+      'createdAt': Timestamp.now(),
+      'modifiedAt': Timestamp.now(),
+    });
+    final courseRef = fake.collection('courses').doc('c1');
+    final items = [
+      TeachableItem(
+        courseId: courseRef,
+        categoryId: catRef,
+        name: 'i1',
+        notes: 'n1',
+        sortOrder: 0,
+        durationInMinutes: 5,
+        inclusionStatus: TeachableItemInclusionStatus.excluded,
+        createdAt: Timestamp.now(),
+        modifiedAt: Timestamp.now(),
+      ),
+      TeachableItem(
+        courseId: courseRef,
+        categoryId: catRef,
+        name: 'i2',
+        notes: 'n2',
+        sortOrder: 1,
+        durationInMinutes: 6,
+        inclusionStatus: TeachableItemInclusionStatus.excluded,
+        createdAt: Timestamp.now(),
+        modifiedAt: Timestamp.now(),
+      ),
+    ];
+    final created = await TeachableItemFunctions.bulkCreateItems(items);
+    expect(created.length, 2);
+    final snapshot = await fake.collection('teachableItems').get();
+    expect(snapshot.docs.length, 2);
+    expect(created.first.name, 'i1');
+  });
+
+  test('updateItem updates fields and deleteItem reorders', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final i1 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    final i2 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat.id!, name: 'i2');
+    await TeachableItemFunctions.updateItem(
+      itemId: i1!.id!,
+      name: 'i1u',
+      notes: 'note',
+      durationInMinutes: 10,
+      inclusionStatus: TeachableItemInclusionStatus.explicitlyIncluded,
+    );
+    final updated = await TeachableItemFunctions.getItemById(i1.id!);
+    expect(updated?.notes, 'note');
+    expect(updated?.durationInMinutes, 10);
+    expect(updated?.inclusionStatus,
+        TeachableItemInclusionStatus.explicitlyIncluded);
+
+    await TeachableItemFunctions.deleteItem(itemId: i1.id!);
+    final remaining = await TeachableItemFunctions.getItemsForCourse('c1');
+    expect(remaining.length, 1);
+    expect(remaining.first.id, i2!.id);
+    expect(remaining.first.sortOrder, 0);
+  });
+
+  test('assignTagToItem and removeItemTagFromItem manage tags', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final item = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    final tagRef = fake.collection('teachableItemTags').doc('tag1');
+    await tagRef.set({'courseId': fake.collection('courses').doc('c1')});
+    await TeachableItemFunctions.assignTagToItem(
+        itemId: item!.id!, tagRef: tagRef);
+    var snap = await fake.collection('teachableItems').doc(item.id!).get();
+    expect((snap.data()!['tagIds'] as List).length, 1);
+    await TeachableItemFunctions.removeItemTagFromItem(
+        itemId: item.id!, tagRef: tagRef);
+    snap = await fake.collection('teachableItems').doc(item.id!).get();
+    expect((snap.data()!['tagIds'] as List).isEmpty, true);
+  });
+
+  test('updateItemSortOrder reorders within and across categories', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat1 = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c1');
+    final cat2 = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c2');
+    final i1 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat1!.id!, name: 'i1');
+    final i2 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat1.id!, name: 'i2');
+    final i3 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat1.id!, name: 'i3');
+    final list = await TeachableItemFunctions.getItemsForCourse('c1');
+    await TeachableItemFunctions.updateItemSortOrder(
+        allItemsAcrossCategories: list,
+        movedItem: i3!,
+        newCategoryRef: fake.collection('teachableItemCategories').doc(cat1.id!),
+        newIndex: 0);
+    var after = await TeachableItemFunctions.getItemsForCourse('c1');
+    final cat1Items = after
+        .where((e) => e.categoryId.id == cat1.id)
+        .toList()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    expect(cat1Items.first.id, i3.id);
+
+    await TeachableItemFunctions.updateItemSortOrder(
+        allItemsAcrossCategories: after,
+        movedItem: cat1Items.first,
+        newCategoryRef:
+            fake.collection('teachableItemCategories').doc(cat2!.id!),
+        newIndex: 0);
+    after = await TeachableItemFunctions.getItemsForCourse('c1');
+    final cat2Items = after
+        .where((e) => e.categoryId.id == cat2.id)
+        .toList()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    expect(cat2Items.first.id, i3.id);
+  });
+
+  test('getItemsForCourse and getItemById retrieve items', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final item = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    final list = await TeachableItemFunctions.getItemsForCourse('c1');
+    expect(list.length, 1);
+    final fetched = await TeachableItemFunctions.getItemById(item!.id!);
+    expect(fetched?.name, 'i1');
+  });
+
+  test('dependency functions add, toggle, and remove prerequisites', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final i1 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    final i2 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat.id!, name: 'i2');
+    var updated = await TeachableItemFunctions.addDependency(
+        target: i1!, dependency: i2!, required: true);
+    expect(updated?.requiredPrerequisiteIds?.length, 1);
+    updated = await TeachableItemFunctions.toggleDependency(
+        target: updated!, dependency: i2);
+    expect(updated?.recommendedPrerequisiteIds?.length, 1);
+    updated = await TeachableItemFunctions.removeDependency(
+        target: updated!, dependency: i2);
+    expect(updated?.recommendedPrerequisiteIds?.isEmpty ?? true, true);
+  });
+
+  test('updateInclusionStatuses and updateDurationOverride modify fields',
+      () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final i1 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    final i2 = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat.id!, name: 'i2');
+    i1!.inclusionStatus = TeachableItemInclusionStatus.explicitlyIncluded;
+    TeachableItemFunctions.updateInclusionStatuses({i1}, {i2!});
+    await Future.delayed(const Duration(milliseconds: 10));
+    var first = await TeachableItemFunctions.getItemById(i1.id!);
+    var second = await TeachableItemFunctions.getItemById(i2.id!);
+    expect(first?.inclusionStatus,
+        TeachableItemInclusionStatus.explicitlyIncluded);
+    expect(second?.inclusionStatus, TeachableItemInclusionStatus.excluded);
+
+    await TeachableItemFunctions.updateDurationOverride(first!, 15);
+    first = await TeachableItemFunctions.getItemById(i1.id!);
+    expect(first?.durationInMinutes, 15);
+  });
+
+  test('lesson association helpers manage lessonRefs', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final item = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat!.id!, name: 'i1');
+    await fake.collection('lessons').doc('l1').set({'name': 'l1'});
+    await fake.collection('lessons').doc('l2').set({'name': 'l2'});
+    var updated = await TeachableItemFunctions.addLessonToTeachableItem(
+        itemId: item!.id!, lessonId: 'l1');
+    expect(updated?.lessonRefs?.length, 1);
+    updated = await TeachableItemFunctions.replaceLessonOnItem(
+        itemId: item.id!, oldLessonId: 'l1', newLessonId: 'l2');
+    expect(updated?.lessonRefs?.first.id, 'l2');
+    updated = await TeachableItemFunctions.removeLessonFromTeachableItem(
+        itemId: item.id!, lessonId: 'l2');
+    expect(updated?.lessonRefs?.isEmpty ?? true, true);
   });
 }


### PR DESCRIPTION
## Summary
- add bulk creation test for teachable items
- cover updates, deletion, tag ops, reordering and retrieval
- verify dependency, inclusion, duration and lesson association helpers

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5db49964832e9c4dfc112d22ee37