### PR TITLE
test: expand teachable item category coverage

### DIFF
--- a/test/teachable_item_category_functions_test.dart
+++ b/test/teachable_item_category_functions_test.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
 import 'package:social_learning/data/firestore_service.dart';
 
 void main() {
@@ -20,5 +21,107 @@ void main() {
     await fake.collection('courses').doc('c1').set({'title': 't'});
     final cat = await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
     expect(cat?.name, 'cat');
+  });
+
+  test('addCategory assigns incrementing sortOrder', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final first =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'a');
+    final second =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'b');
+    expect(first?.sortOrder, 0);
+    expect(second?.sortOrder, 1);
+  });
+
+  test('bulkCreateCategories creates sequential categories', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cats = await TeachableItemCategoryFunctions.bulkCreateCategories(
+        courseId: 'c1', names: ['a', 'b', 'c']);
+    expect(cats.map((c) => c.name), ['a', 'b', 'c']);
+    expect(cats.map((c) => c.sortOrder), [0, 1, 2]);
+  });
+
+  test('updateCategory changes the name', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'old');
+    await TeachableItemCategoryFunctions.updateCategory(
+        categoryId: cat!.id!, name: 'new');
+    final snap =
+        await fake.collection('teachableItemCategories').doc(cat.id).get();
+    expect(snap.data()!['name'], 'new');
+  });
+
+  test('deleteCategory removes category, items, and updates sortOrder', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final cat1 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c1');
+    final cat2 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c2');
+    final cat3 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c3');
+
+    await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat2!.id!, name: 'i1');
+    await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: cat2.id!, name: 'i2');
+
+    await TeachableItemCategoryFunctions.deleteCategory(categoryId: cat2.id!);
+
+    final cat2Snap =
+        await fake.collection('teachableItemCategories').doc(cat2.id).get();
+    expect(cat2Snap.exists, isFalse);
+    final itemsSnap = await fake.collection('teachableItems').get();
+    expect(itemsSnap.docs, isEmpty);
+    final cat1Snap =
+        await fake.collection('teachableItemCategories').doc(cat1!.id!).get();
+    final cat3Snap =
+        await fake.collection('teachableItemCategories').doc(cat3!.id!).get();
+    expect(cat1Snap.data()!['sortOrder'], 0);
+    expect(cat3Snap.data()!['sortOrder'], 1);
+  });
+
+  test('updateCategorySortOrder reorders categories', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final c1 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'a');
+    final c2 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'b');
+    final c3 =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c');
+    await TeachableItemCategoryFunctions.updateCategorySortOrder(
+        movedCategory: c3!, newIndex: 1, allCategoriesForCourse: [c1!, c2!, c3]);
+    final categories =
+        await TeachableItemCategoryFunctions.getCategoriesForCourse('c1');
+    expect(categories.map((c) => c.name), ['a', 'c', 'b']);
+    expect(categories.map((c) => c.sortOrder), [0, 1, 2]);
+  });
+
+  test('getCategoriesForCourse returns sorted categories for a course', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    await fake.collection('courses').doc('c2').set({'title': 't2'});
+    final a =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'a');
+    final b =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'b');
+    final c =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'c');
+    await fake
+        .collection('teachableItemCategories')
+        .doc(a!.id!)
+        .update({'sortOrder': 2});
+    await fake
+        .collection('teachableItemCategories')
+        .doc(b!.id!)
+        .update({'sortOrder': 0});
+    await fake
+        .collection('teachableItemCategories')
+        .doc(c!.id!)
+        .update({'sortOrder': 1});
+    await TeachableItemCategoryFunctions.addCategory(courseId: 'c2', name: 'x');
+    final result =
+        await TeachableItemCategoryFunctions.getCategoriesForCourse('c1');
+    expect(result.length, 3);
+    expect(result.map((c) => c.name), ['b', 'c', 'a']);
   });
 }


### PR DESCRIPTION
## Summary
- add tests for sequential category creation and reordering
- cover updating, deleting and querying teachable item categories

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5daeff6c832e8bc7ec6f83de9b21