### PR TITLE
Refactor library state initialization

### DIFF
--- a/lib/data/data_helpers/course_functions.dart
+++ b/lib/data/data_helpers/course_functions.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+class CourseFunctions {
+  static StreamSubscription<List<Course>> listenPublicCourses(
+      void Function(List<Course>) onData,
+      {Function? onError}) {
+    return FirestoreService.instance
+        .collection('courses')
+        .where('isPrivate', isEqualTo: false)
+        .snapshots()
+        .listen((snapshot) {
+      onData(snapshot.docs.map((e) => Course.fromSnapshot(e)).toList());
+    }, onError: onError);
+  }
+
+  static Future<List<Course>> fetchEnrolledPrivateCourses(
+      List<String> enrolledCourseIds) async {
+    if (enrolledCourseIds.isEmpty) {
+      return [];
+    }
+
+    final snapshot = await FirestoreService.instance
+        .collection('courses')
+        .where(FieldPath.documentId, whereIn: enrolledCourseIds)
+        .where('isPrivate', isEqualTo: true)
+        .get();
+    return snapshot.docs.map((e) => Course.fromSnapshot(e)).toList();
+  }
+
+  static Future<bool> titleExists(String title) async {
+    final snapshot = await FirestoreService.instance
+        .collection('courses')
+        .where('title', isEqualTo: title)
+        .get();
+    return snapshot.docs.isNotEmpty;
+  }
+
+  static Future<bool> invitationCodeExists(String invitationCode) async {
+    final snapshot = await FirestoreService.instance
+        .collection('courses')
+        .where('invitationCode', isEqualTo: invitationCode)
+        .get();
+    return snapshot.docs.isNotEmpty;
+  }
+
+  static Future<DocumentReference<Map<String, dynamic>>> createPrivateCourse(
+      {required String title,
+      required String description,
+      required String invitationCode,
+      required String creatorId}) {
+    return FirestoreService.instance.collection('courses').add({
+      'title': title,
+      'description': description,
+      'creatorId': creatorId,
+      'isPrivate': true,
+      'invitationCode': invitationCode,
+    });
+  }
+
+  static Future<Course?> findCourseByInvitationCode(String code) async {
+    final snapshot = await FirestoreService.instance
+        .collection('courses')
+        .where('invitationCode', isEqualTo: code)
+        .get();
+    if (snapshot.docs.isEmpty) {
+      return null;
+    }
+    return Course.fromSnapshot(snapshot.docs.first);
+  }
+}
+

--- a/lib/data/data_helpers/lesson_comment_functions.dart
+++ b/lib/data/data_helpers/lesson_comment_functions.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+class LessonCommentFunctions {
+  static Future<void> addComment({
+    required String lessonId,
+    required String userId,
+    required String creatorUid,
+    required String text,
+  }) {
+    final lessonRef = FirestoreService.instance.doc('/lessons/$lessonId');
+    final userRef = FirestoreService.instance.doc('/users/$userId');
+    return FirestoreService.instance.collection('lessonComments').add({
+      'lessonId': lessonRef,
+      'text': text,
+      'creatorId': userRef,
+      'creatorUid': creatorUid,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  static Future<void> deleteComment(String commentId) {
+    return FirestoreService.instance.doc('/lessonComments/$commentId').delete();
+  }
+}
+

--- a/lib/data/data_helpers/lesson_functions.dart
+++ b/lib/data/data_helpers/lesson_functions.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as auth;
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/lesson.dart';
+
+class LessonFunctions {
+  static StreamSubscription<List<Lesson>> listenLessons(
+      String courseId, void Function(List<Lesson>) onData) {
+    final coursePath = '/courses/$courseId';
+    return FirestoreService.instance
+        .collection('lessons')
+        .where('courseId',
+            isEqualTo: FirestoreService.instance.doc(coursePath))
+        .orderBy('sortOrder', descending: false)
+        .snapshots()
+        .listen((snapshot) {
+      onData(snapshot.docs.map((e) => Lesson.fromSnapshot(e)).toList());
+    });
+  }
+
+  static Future<void> setSortOrder(String lessonId, int newSortOrder) {
+    return FirestoreService.instance.doc('/lessons/$lessonId').set({
+      'sortOrder': newSortOrder,
+      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> deleteLesson(String lessonId) {
+    return FirestoreService.instance.doc('/lessons/$lessonId').delete();
+  }
+
+  static Future<void> deleteCoverPhoto(String lessonId) async {
+    final storageRef =
+        FirebaseStorage.instance.ref('/lesson_covers/$lessonId/coverPhoto');
+    await storageRef.delete();
+  }
+
+  static Future<DocumentReference<Map<String, dynamic>>> createLesson({
+    required String courseId,
+    DocumentReference? levelId,
+    required int sortOrder,
+    required String title,
+    String? synopsis,
+    required String instructions,
+    String? recapVideo,
+    String? lessonVideo,
+    String? practiceVideo,
+    List<String>? graduationRequirements,
+    required String creatorId,
+  }) {
+    return FirestoreService.instance.collection('lessons').add({
+      'courseId': FirestoreService.instance.doc('/courses/$courseId'),
+      'levelId': levelId,
+      'sortOrder': sortOrder,
+      'title': title,
+      'synopsis': synopsis,
+      'instructions': instructions,
+      'recapVideo': recapVideo,
+      'lessonVideo': lessonVideo,
+      'practiceVideo': practiceVideo,
+      'creatorId': creatorId,
+      'graduationRequirements': graduationRequirements,
+    });
+  }
+
+  static Future<void> updateLesson(String lessonId, Map<String, dynamic> data) {
+    return FirestoreService.instance
+        .doc('/lessons/$lessonId')
+        .set(data, SetOptions(merge: true));
+  }
+
+  static Future<void> attachLessonToLevel(
+      String lessonId, String levelId) async {
+    await FirestoreService.instance.doc('/lessons/$lessonId').set({
+      'levelId': FirestoreService.instance.doc('/levels/$levelId'),
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> detachLesson(String lessonId) {
+    return FirestoreService.instance.doc('/lessons/$lessonId').set({
+      'levelId': null,
+    }, SetOptions(merge: true));
+  }
+
+  @Deprecated('Left over from the first version of the CMS.')
+  static Future<void> createLessonLegacy(
+      String courseId, String title, String instructions, bool isLevel) {
+    return FirestoreService.instance.collection('lessons').add({
+      'courseId': FirestoreService.instance.doc('/courses/$courseId'),
+      'sortOrder': 0,
+      'title': title,
+      'instructions': instructions,
+      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
+      'isLevel': isLevel,
+    }).then((_) => null);
+  }
+
+  @Deprecated('Left over from the first version of the CMS.')
+  static Future<void> updateLessonLegacy(
+      String lessonId, String title, String instructions, bool isLevel) {
+    return FirestoreService.instance.doc('/lessons/$lessonId').set({
+      'title': title,
+      'instructions': instructions,
+      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
+      'isLevel': isLevel,
+    }, SetOptions(merge: true));
+  }
+}
+

--- a/lib/data/data_helpers/level_functions.dart
+++ b/lib/data/data_helpers/level_functions.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as auth;
+import 'package:social_learning/data/Level.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+class LevelFunctions {
+  static StreamSubscription<List<Level>> listenLevels(
+      String courseId, void Function(List<Level>) onData) {
+    final coursePath = '/courses/$courseId';
+    return FirestoreService.instance
+        .collection('levels')
+        .where('courseId',
+            isEqualTo: FirestoreService.instance.doc(coursePath))
+        .orderBy('sortOrder', descending: false)
+        .snapshots()
+        .listen((snapshot) {
+      onData(snapshot.docs.map((e) => Level.fromQuerySnapshot(e)).toList());
+    });
+  }
+
+  static Future<void> setSortOrder(String levelId, int newSortOrder) {
+    return FirestoreService.instance.doc('/levels/$levelId').set({
+      'sortOrder': newSortOrder,
+      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
+    }, SetOptions(merge: true));
+  }
+
+  static Future<void> updateLevel(String levelId, Map<String, dynamic> data) {
+    return FirestoreService.instance
+        .doc('/levels/$levelId')
+        .set(data, SetOptions(merge: true));
+  }
+
+  static Future<void> deleteLevel(String levelId) {
+    return FirestoreService.instance.doc('/levels/$levelId').delete();
+  }
+
+  static Future<DocumentReference<Map<String, dynamic>>> addLevel({
+    required String courseId,
+    required String title,
+    required String description,
+    required int sortOrder,
+    required String creatorId,
+  }) {
+    return FirestoreService.instance.collection('levels').add({
+      'courseId': FirestoreService.instance.doc('/courses/$courseId'),
+      'title': title,
+      'description': description,
+      'sortOrder': sortOrder,
+      'creatorId': creatorId,
+    });
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -72,6 +74,8 @@ void main() async {
   ApplicationState applicationState = ApplicationState();
   LibraryState libraryState = LibraryState(applicationState);
   CourseDesignerState courseDesignerState = CourseDesignerState(libraryState);
+
+  unawaited(libraryState.initialize());
 
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.dumpErrorToConsole(details);

--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -3,253 +3,164 @@ import 'dart:collection';
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
-// import 'package:googleapis/docs/v1.dart';
 import 'package:social_learning/data/Level.dart';
 import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/lesson.dart';
-import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:social_learning/data/lesson_comment.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:collection/collection.dart';
 import 'package:social_learning/state/student_state.dart';
+import 'package:social_learning/data/data_helpers/course_functions.dart';
+import 'package:social_learning/data/data_helpers/lesson_functions.dart';
+import 'package:social_learning/data/data_helpers/level_functions.dart';
+import 'package:social_learning/data/data_helpers/lesson_comment_functions.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
 
 class LibraryState extends ChangeNotifier {
   final ApplicationState _applicationState;
 
-  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>?
-      _publicCourseListListener;
+  StreamSubscription<List<Course>>? _publicCourseListListener;
 
-  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _levelListListener;
+  StreamSubscription<List<Level>>? _levelListListener;
 
-  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _lessonListListener;
+  StreamSubscription<List<Lesson>>? _lessonListListener;
 
   bool get isCourseSelected => _selectedCourse != null;
 
   Course? _selectedCourse;
-  bool _isSelectedCourseInitializedFromDb = false;
+  bool _isInitialized = false;
+  late Completer<void> _initializationCompleter;
 
-  Course? get selectedCourse {
-    if (_selectedCourse == null &&
-        availableCourses.isNotEmpty &&
-        !_isSelectedCourseInitializedFromDb) {
-      var currentCourseId = _applicationState.currentUser?.currentCourseId;
-      if (currentCourseId != null) {
-        Course? foundCourse = availableCourses
-            .firstWhereOrNull((course) => course.id == currentCourseId.id);
-
-        if (foundCourse != null) {
-          _isSelectedCourseInitializedFromDb = true;
-          selectedCourse = foundCourse;
-        }
-      }
-    }
-
-    return _selectedCourse;
-  }
+  Course? get selectedCourse => _selectedCourse;
 
   set selectedCourse(Course? course) {
     if (_selectedCourse != course) {
+      _lessonListListener?.cancel();
+      _levelListListener?.cancel();
       _lessons = null;
-      _isLessonListLoaded = false;
-      _isLevelListLoaded = false;
+      _levels = null;
+
+      _selectedCourse = course;
+
+      if (course?.id != null) {
+        _loadSelectedCourseData(course!.id!);
+      }
+
+      String? courseId = course?.id;
+      User? currentUser = _applicationState.currentUser;
+      if (courseId != null &&
+          currentUser != null &&
+          currentUser.currentCourseId?.id != courseId) {
+        UserFunctions.updateCurrentCourse(currentUser, courseId);
+      }
+
+      print('LibraryState.notifyListeners because of selectedCourse');
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
     }
-
-    _selectedCourse = course;
-
-    String? courseId = course?.id;
-    User? currentUser = _applicationState.currentUser;
-    if (courseId != null &&
-        currentUser != null &&
-        currentUser.currentCourseId?.id != courseId) {
-      () async {
-        FirebaseFirestore.instance.collection('users').doc(currentUser.id).set({
-          'currentCourseId':
-              FirebaseFirestore.instance.doc('/courses/$courseId')
-        }, SetOptions(merge: true));
-      }();
-    }
-
-    print('LibraryState.notifyListeners because of selectedCourse');
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      notifyListeners();
-    });
   }
 
   var _availableCourses = <Course>[];
   var _publicCourses = <Course>[];
   var _enrolledPrivateCourses = <Course>[];
-  bool _isCourseListLoaded = false;
-  bool _isCourseListPending = false;
-  Completer<void>? _courseListCompleter;
-  bool _hasLoadedPublicCourses = false;
-  bool _hasLoadedEnrolledCourses = false;
 
-  bool get isCourseListPending => _isCourseListPending;
-
-  List<Course> get availableCourses {
-    if (!_isCourseListLoaded) {
-      _isCourseListLoaded = true;
-      loadCourseList();
-    }
-    return _availableCourses;
-  }
+  List<Course> get availableCourses => _availableCourses;
 
   List<Lesson>? _lessons;
-  bool _isLessonListLoaded = false;
-
-  List<Lesson>? get lessons {
-    if (!_isLessonListLoaded) {
-      _isLessonListLoaded = true;
-      loadLessonList();
-    }
-    return _lessons;
-  }
+  List<Lesson>? get lessons => _lessons;
 
   List<Level>? _levels;
-  bool _isLevelListLoaded = false;
-
-  List<Level>? get levels {
-    if (!_isLevelListLoaded) {
-      _isLevelListLoaded = true;
-      loadLevelList();
-    }
-    return _levels;
-  }
+  List<Level>? get levels => _levels;
 
   LibraryState(this._applicationState) {
+    _initializationCompleter = Completer<void>();
     _applicationState.addListener(() {
       _reloadEnrolledCourses();
+      final currentCourseId =
+          _applicationState.currentUser?.currentCourseId?.id;
+      if (currentCourseId != null &&
+          (_selectedCourse == null || _selectedCourse!.id != currentCourseId)) {
+        final Course? found =
+            _availableCourses.firstWhereOrNull((c) => c.id == currentCourseId);
+        if (found != null) {
+          selectedCourse = found;
+        }
+      }
     });
   }
 
-  Future<void> ensureSelectedCourseLoaded() async {
-    if (_selectedCourse != null || _isSelectedCourseInitializedFromDb) {
-      return;
+  Future<void> initialize() async {
+    if (_isInitialized) {
+      return _initializationCompleter.future;
     }
+    _isInitialized = true;
 
-    // Trigger loading of courses.
-    availableCourses;
-
-    // Wait for the current user to be loaded.
-    await _applicationState.currentUserBlocking;
-
-    final String? currentCourseId =
+    final currentCourseId =
         _applicationState.currentUser?.currentCourseId?.id;
-    if (currentCourseId == null) {
-      _isSelectedCourseInitializedFromDb = true;
-      return;
+
+    final futures = <Future<void>>[loadCourseList()];
+    if (currentCourseId != null) {
+      futures.add(_loadSelectedCourseData(currentCourseId));
     }
 
-    final Course? immediateCourse =
-        _availableCourses.firstWhereOrNull((c) => c.id == currentCourseId);
-    if (immediateCourse != null) {
-      _isSelectedCourseInitializedFromDb = true;
-      selectedCourse = immediateCourse;
-      return;
+    await Future.wait(futures);
+
+    if (currentCourseId != null) {
+      final Course? course =
+          _availableCourses.firstWhereOrNull((c) => c.id == currentCourseId);
+      if (course != null) {
+        _selectedCourse = course;
+      }
     }
 
-    if (_isCourseListPending) {
-      await _courseListCompleter?.future;
-    }
-
-    final Course? foundCourse =
-        _availableCourses.firstWhereOrNull((c) => c.id == currentCourseId);
-    if (foundCourse != null) {
-      _isSelectedCourseInitializedFromDb = true;
-      selectedCourse = foundCourse;
-    } else {
-      _isSelectedCourseInitializedFromDb = true;
-    }
+    _initializationCompleter.complete();
+    return _initializationCompleter.future;
   }
 
+  Future<void> get initialized => _initializationCompleter.future;
+
   Future<void> loadCourseList() async {
-    // Create courses.
-    // FirebaseFirestore.instance.collection('courses').add(<String, dynamic>{
-    //   'title': 'Argentine Tango',
-    //   'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-    // });
+    _publicCourseListListener?.cancel();
+    final publicCompleter = Completer<void>();
 
-    if (_publicCourseListListener != null) {
-      _publicCourseListListener?.cancel();
-    }
-
-    _courseListCompleter = Completer<void>();
-    _hasLoadedPublicCourses = false;
-    _hasLoadedEnrolledCourses = false;
-    _isCourseListPending = true;
-
-    _publicCourseListListener = FirebaseFirestore.instance
-        .collection('courses')
-        .where('isPrivate', isEqualTo: false)
-        .snapshots()
-        .listen((snapshot) {
-      _publicCourses =
-          snapshot.docs.map((e) => Course.fromSnapshot(e)).toList();
+    _publicCourseListListener = CourseFunctions.listenPublicCourses((courses) {
+      _publicCourses = courses;
       _rebuildAvailableCourses();
-      _hasLoadedPublicCourses = true;
-      _maybeCompleteCourseList();
+      if (!publicCompleter.isCompleted) {
+        publicCompleter.complete();
+      }
       print('Loaded ${_publicCourses.length} public courses');
       notifyListeners();
     }, onError: (error, stackTrace) {
       print('Failed to load public courses: $error');
     });
 
-    _reloadEnrolledCourses();
+    await Future.wait([publicCompleter.future, _reloadEnrolledCourses()]);
   }
 
   Future<void> _reloadEnrolledCourses() async {
-    _hasLoadedEnrolledCourses = false;
-    _isCourseListPending = true;
-    if (_courseListCompleter == null || _courseListCompleter!.isCompleted) {
-      _courseListCompleter = Completer<void>();
-    }
-
     var enrolledCourseIds = _applicationState.currentUser?.enrolledCourseIds;
 
     if (enrolledCourseIds != null && enrolledCourseIds.isNotEmpty) {
-      QuerySnapshot<Map<String, dynamic>> snapshot = await FirebaseFirestore
-          .instance
-          .collection('courses')
-          .where(FieldPath.documentId, whereIn: enrolledCourseIds)
-          .where('isPrivate', isEqualTo: true)
-          .get()
-          .onError((Object error, StackTrace stackTrace) {
-        print('Failed to load private courses: $error');
-        return Future.error(error, stackTrace);
-      });
       _enrolledPrivateCourses =
-          snapshot.docs.map((e) => Course.fromSnapshot(e)).toList();
+          await CourseFunctions.fetchEnrolledPrivateCourses(enrolledCourseIds);
       _rebuildAvailableCourses();
-      _hasLoadedEnrolledCourses = true;
-      _maybeCompleteCourseList();
       print('Loaded ${_enrolledPrivateCourses.length} enrolled courses');
       notifyListeners();
     } else {
       if (_enrolledPrivateCourses.isNotEmpty) {
         _enrolledPrivateCourses = [];
         _rebuildAvailableCourses();
-
         WidgetsBinding.instance.addPostFrameCallback((_) {
           print(
               'LibraryState.notifyListeners because of reload private courses.');
           notifyListeners();
         });
-      }
-      _hasLoadedEnrolledCourses = true;
-      _maybeCompleteCourseList();
-    }
-  }
-
-  void _maybeCompleteCourseList() {
-    if (_hasLoadedPublicCourses && _hasLoadedEnrolledCourses) {
-      _isCourseListPending = false;
-      if (_courseListCompleter != null && !_courseListCompleter!.isCompleted) {
-        _courseListCompleter!.complete();
       }
     }
   }
@@ -261,70 +172,47 @@ class LibraryState extends ChangeNotifier {
       ..sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
   }
 
-  Future<void> loadLessonList() async {
-    // Create courses.
-    // FirebaseFirestore.instance.collection('lessons').add(<String, dynamic>{
-    //   'courseId': FirebaseFirestore.instance.doc('/courses/4ZUgIakaAbcCiVWMxSKb'),
-    //   'sortOrder': 1,
-    //   'title': 'Wohoo!',
-    //   'instructions': 'Couple work: Basic and inside turn',
-    //   'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-    //   'isLevel': false,
-    // });
-    // FirebaseFirestore.instance.collection('lessons').add(<String, dynamic>{
-    //   'courseId': FirebaseFirestore.instance.doc('/courses/4ZUgIakaAbcCiVWMxSKb'),
-    //   'sortOrder': 2,
-    //   'title': 'First dance',
-    //   'instructions': 'Couple work: Basic and inside turn',
-    //   'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-    //   'isLevel': false,
-    // });
+  Future<void> _loadSelectedCourseData(String courseId) {
+    return Future.wait([loadLessonList(courseId), loadLevelList(courseId)]);
+  }
 
-    var courseId = selectedCourse?.id;
+  Future<void> loadLessonList([String? courseId]) async {
+    courseId = courseId ?? _selectedCourse?.id;
     if (courseId != null) {
-      if (_lessonListListener != null) {
-        _lessonListListener?.cancel();
-        _lessonListListener = null;
-      }
+      _lessonListListener?.cancel();
+      final completer = Completer<void>();
 
-      String coursePath = '/courses/$courseId';
-
-      _lessonListListener = FirebaseFirestore.instance
-          .collection('lessons')
-          .where('courseId',
-              isEqualTo: FirebaseFirestore.instance.doc(coursePath))
-          .orderBy('sortOrder', descending: false)
-          .snapshots()
-          .listen((snapshot) {
-        _lessons = snapshot.docs.map((e) => Lesson.fromSnapshot(e)).toList();
+      _lessonListListener =
+          LessonFunctions.listenLessons(courseId, (lessonList) {
+        _lessons = lessonList;
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
         print('Loaded ${_lessons?.length} lessons');
         notifyListeners();
       });
+
+      await completer.future;
     }
   }
 
-  Future<void> loadLevelList() async {
-    var courseId = selectedCourse?.id;
+  Future<void> loadLevelList([String? courseId]) async {
+    courseId = courseId ?? _selectedCourse?.id;
     if (courseId != null) {
-      if (_levelListListener != null) {
-        _levelListListener?.cancel();
-        _levelListListener = null;
-      }
+      _levelListListener?.cancel();
+      final completer = Completer<void>();
 
-      String coursePath = '/courses/$courseId';
-
-      _levelListListener = FirebaseFirestore.instance
-          .collection('levels')
-          .where('courseId',
-              isEqualTo: FirebaseFirestore.instance.doc(coursePath))
-          .orderBy('sortOrder', descending: false)
-          .snapshots()
-          .listen((snapshot) {
-        _levels = snapshot.docs.map((e) => Level.fromQuerySnapshot(e)).toList();
+      _levelListListener =
+          LevelFunctions.listenLevels(courseId, (levelList) {
+        _levels = levelList;
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
         print('Loaded ${_levels?.length} levels');
         notifyListeners();
       });
-      // TODO: Cancel this subscription and other subscriptions.
+
+      await completer.future;
     }
   }
 
@@ -430,20 +318,16 @@ class LibraryState extends ChangeNotifier {
   void _setSortOrder(Lesson lesson, int newSortOrder) async {
     print(
         '### Set sort order for ${lesson.title} from ${lesson.sortOrder} to $newSortOrder');
-    await FirebaseFirestore.instance.doc('/lessons/${lesson.id}').set({
-      'sortOrder': newSortOrder,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid
-    }, SetOptions(merge: true)).onError((error, stackTrace) {
-      print('Failed to set sort order: $error');
+    try {
+      await LessonFunctions.setSortOrder(lesson.id!, newSortOrder);
+    } catch (e, stackTrace) {
+      print('Failed to set sort order: $e');
       debugPrintStack(stackTrace: stackTrace);
-    });
+    }
   }
 
   void _setLevelSortOrder(Level level, int newSortOrder) async {
-    await FirebaseFirestore.instance.doc('/levels/${level.id}').set({
-      'sortOrder': newSortOrder,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid
-    }, SetOptions(merge: true));
+    await LevelFunctions.setSortOrder(level.id!, newSortOrder);
   }
 
   void deleteLesson(Lesson deletedLesson) {
@@ -454,7 +338,7 @@ class LibraryState extends ChangeNotifier {
     }
 
     // Delete lesson.
-    FirebaseFirestore.instance.doc('/lessons/${deletedLesson.id}').delete();
+    LessonFunctions.deleteLesson(deletedLesson.id!);
 
     // Update sortOrder for following lessons.
     for (Lesson lesson in lessons) {
@@ -463,32 +347,14 @@ class LibraryState extends ChangeNotifier {
       }
     }
 
-    // TODO: Delete cover photo.
-    _deleteCoverPhoto(deletedLesson);
-  }
-
-  void _deleteCoverPhoto(Lesson lesson) async {
-    var fireStoragePath = '/lesson_covers/${lesson.id}/coverPhoto';
-    var storageRef = FirebaseStorage.instance.ref(fireStoragePath);
-    try {
-      // var imageData = await file.readAsBytes();
-      await storageRef.delete();
-    } catch (e) {
-      print('Error deleting photo: $e');
-    }
+    // Delete cover photo.
+    LessonFunctions.deleteCoverPhoto(deletedLesson.id!);
   }
 
   @Deprecated('Left over from the first version of the CMS.')
   void createLessonLegacy(
       String courseId, String title, String instructions, bool isLevel) async {
-    FirebaseFirestore.instance.collection('lessons').add(<String, dynamic>{
-      'courseId': FirebaseFirestore.instance.doc('/courses/$courseId'),
-      'sortOrder': _lessons?.length ?? 0,
-      'title': title,
-      'instructions': instructions,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-      'isLevel': isLevel,
-    });
+    await LessonFunctions.createLessonLegacy(courseId, title, instructions, isLevel);
   }
 
   Future<Lesson> createLesson(
@@ -505,25 +371,18 @@ class LibraryState extends ChangeNotifier {
     var currentUser = _applicationState.currentUser;
 
     DocumentReference<Map<String, dynamic>> newLessonRef =
-        await FirebaseFirestore.instance
-            .collection('lessons')
-            .add(<String, dynamic>{
-      'courseId':
-          FirebaseFirestore.instance.doc('/courses/${selectedCourse?.id}'),
-      'levelId': levelId,
-      'sortOrder': _findHighestLessonSortOrder() + 1,
-      // TODO: If levelId is null, use the highest sort order of the level.
-      'title': title,
-      'synopsis': synopsis,
-      'instructions': instructions,
-      // 'cover': cover, // TODO: Implement image upload.
-      // 'coverFireStoragePath': coverFireStoragePath,
-      'recapVideo': recapVideo,
-      'lessonVideo': lessonVideo,
-      'practiceVideo': practiceVideo,
-      'creatorId': currentUser!.uid,
-      'graduationRequirements': graduationRequirements,
-    });
+        await LessonFunctions.createLesson(
+            courseId: selectedCourse!.id!,
+            levelId: levelId,
+            sortOrder: _findHighestLessonSortOrder() + 1,
+            title: title,
+            synopsis: synopsis,
+            instructions: instructions,
+            recapVideo: recapVideo,
+            lessonVideo: lessonVideo,
+            practiceVideo: practiceVideo,
+            graduationRequirements: graduationRequirements,
+            creatorId: currentUser!.uid);
 
     if (levelId == null) {
       sortUnattachedLessons();
@@ -542,12 +401,7 @@ class LibraryState extends ChangeNotifier {
   @Deprecated('Left over from the first version of the CMS.')
   void updateLessonLegacy(
       String lessonId, String title, String instructions, bool isLevel) {
-    FirebaseFirestore.instance.doc('/lessons/$lessonId').set({
-      'title': title,
-      'instructions': instructions,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-      'isLevel': isLevel,
-    }, SetOptions(merge: true));
+    LessonFunctions.updateLessonLegacy(lessonId, title, instructions, isLevel);
   }
 
   Future<void> updateLesson(Lesson lesson) async {
@@ -556,7 +410,7 @@ class LibraryState extends ChangeNotifier {
       lesson.graduationRequirements!.removeWhere((element) => element.isEmpty);
     }
 
-    await FirebaseFirestore.instance.doc('/lessons/${lesson.id}').set({
+    await LessonFunctions.updateLesson(lesson.id!, {
       'levelId': lesson.levelId,
       'sortOrder': lesson.sortOrder,
       'title': lesson.title,
@@ -568,15 +422,15 @@ class LibraryState extends ChangeNotifier {
       'lessonVideo': lesson.lessonVideo,
       'practiceVideo': lesson.practiceVideo,
       'graduationRequirements': lesson.graduationRequirements,
-    }, SetOptions(merge: true));
+    });
   }
 
   void updateLevel(Level level) async {
-    await FirebaseFirestore.instance.doc('levels/${level.id}').set({
+    await LevelFunctions.updateLevel(level.id!, {
       'title': level.title,
       'description': level.description,
       'sortOrder': level.sortOrder,
-    }, SetOptions(merge: true));
+    });
   }
 
   Level? findLevel(String levelId) =>
@@ -594,18 +448,13 @@ class LibraryState extends ChangeNotifier {
       String description,
       ApplicationState applicationState,
       LibraryState libraryState) async {
-    DocumentReference<Map<String, dynamic>> docRef = await FirebaseFirestore
-        .instance
-        .collection('/courses')
-        .add(<String, dynamic>{
-      'title': courseName,
-      'description': description,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-      'isPrivate': true,
-      'invitationCode': invitationCode
-    });
-    var doc = await docRef.get();
-    var course = Course.fromDocument(doc);
+    DocumentReference<Map<String, dynamic>> docRef =
+        await CourseFunctions.createPrivateCourse(
+            title: courseName,
+            description: description,
+            invitationCode: invitationCode,
+            creatorId: _applicationState.currentUser!.uid);
+    var course = Course.fromDocument(await docRef.get());
 
     // Automatically enroll the creator in their own course.
     _applicationState.enrollInPrivateCourse(course);
@@ -614,28 +463,15 @@ class LibraryState extends ChangeNotifier {
   }
 
   Future<Course?> joinPrivateCourse(String invitationCode) async {
-    var snapshot = await FirebaseFirestore.instance
-        .collection('courses')
-        .where('invitationCode', isEqualTo: invitationCode)
-        .get();
-    if (snapshot.docs.isNotEmpty) {
-      var course = Course.fromSnapshot(snapshot.docs.first);
-
-      // Enroll in the private course.
+    final course =
+        await CourseFunctions.findCourseByInvitationCode(invitationCode);
+    if (course != null) {
       await _applicationState.enrollInPrivateCourse(course);
-
-      // Load the enrolled course into LibraryState.
       await _reloadEnrolledCourses();
-
-      // Select the private course.
-      selectedCourse = _availableCourses
-          .firstWhereOrNull((element) => element.id == course.id);
-
-      return course;
-    } else {
-      // Course not found.
-      return Future.value(null);
+      selectedCourse =
+          _availableCourses.firstWhereOrNull((element) => element.id == course.id);
     }
+    return course;
   }
 
   void deleteLevel(Level level) {
@@ -651,7 +487,7 @@ class LibraryState extends ChangeNotifier {
     }
 
     // Delete level.
-    FirebaseFirestore.instance.doc('/levels/${level.id}').delete();
+    LevelFunctions.deleteLevel(level.id!);
 
     // Update sortOrder for following levels.
     for (Level otherLevel in levels) {
@@ -664,14 +500,12 @@ class LibraryState extends ChangeNotifier {
   void addLevel(String title, String description) async {
     var sortOrder = _findHighestLevelSortOrder();
 
-    await FirebaseFirestore.instance.collection('/levels').add({
-      'courseId':
-          FirebaseFirestore.instance.doc('/courses/${selectedCourse?.id}'),
-      'title': title,
-      'description': description,
-      'sortOrder': sortOrder + 1,
-      'creatorId': auth.FirebaseAuth.instance.currentUser!.uid,
-    });
+    await LevelFunctions.addLevel(
+        courseId: selectedCourse!.id!,
+        title: title,
+        description: description,
+        sortOrder: sortOrder + 1,
+        creatorId: _applicationState.currentUser!.uid);
   }
 
   _findHighestLevelSortOrder() {
@@ -702,9 +536,7 @@ class LibraryState extends ChangeNotifier {
 
   void detachLesson(Lesson lesson) async {
     // Remove the level.
-    await FirebaseFirestore.instance.doc('/lessons/${lesson.id}').set({
-      'levelId': null,
-    }, SetOptions(merge: true));
+    await LessonFunctions.detachLesson(lesson.id!);
 
     // Sort the unattached lessons.
     var unattachedLessons = getUnattachedLessons().toList();
@@ -730,9 +562,7 @@ class LibraryState extends ChangeNotifier {
   }
 
   void attachLesson(Level level, Lesson selectedLesson, int sortOrder) async {
-    await FirebaseFirestore.instance.doc('/lessons/${selectedLesson.id}').set({
-      'levelId': FirebaseFirestore.instance.doc('/levels/${level.id}'),
-    }, SetOptions(merge: true));
+    await LessonFunctions.attachLessonToLevel(selectedLesson.id!, level.id!);
 
     updateSortOrder(selectedLesson, sortOrder);
 
@@ -813,58 +643,29 @@ class LibraryState extends ChangeNotifier {
 
   addLessonComment(Lesson lesson, String comment) async {
     User user = _applicationState.currentUser!;
-    DocumentReference userId =
-        FirebaseFirestore.instance.doc('/users/${user.id}');
-    DocumentReference lessonId =
-        FirebaseFirestore.instance.doc('/lessons/${lesson.id}');
-
-    await FirebaseFirestore.instance.collection('lessonComments').add({
-      'lessonId': lessonId,
-      'text': comment,
-      'creatorId': userId,
-      'creatorUid': user.uid,
-      'createdAt': FieldValue.serverTimestamp(),
-    });
-    print('finished firebase call to create comment');
+    await LessonCommentFunctions.addComment(
+        lessonId: lesson.id!,
+        userId: user.id,
+        creatorUid: user.uid,
+        text: comment);
   }
 
   deleteLessonComment(LessonComment comment) async {
     print('Deleting comment: ${comment.id}');
-    await FirebaseFirestore.instance
-        .doc('/lessonComments/${comment.id}')
-        .delete()
-        .onError((error, stackTrace) {
+    try {
+      await LessonCommentFunctions.deleteComment(comment.id!);
+    } catch (error, stackTrace) {
       print('Failed to delete comment: $error');
       debugPrintStack(stackTrace: stackTrace);
-    });
+    }
   }
 
   Future<bool> doesCourseTitleExist(String title) async {
-    return await FirebaseFirestore.instance
-        .collection('courses')
-        .where('title', isEqualTo: title)
-        .get()
-        .then((snapshot) {
-      if (snapshot.docs.isNotEmpty) {
-        return true;
-      } else {
-        return false;
-      }
-    });
+    return CourseFunctions.titleExists(title);
   }
 
   Future<bool> doesInvitationCodeExist(String title) async {
-    return await FirebaseFirestore.instance
-        .collection('courses')
-        .where('invitationCode', isEqualTo: title)
-        .get()
-        .then((snapshot) {
-      if (snapshot.docs.isNotEmpty) {
-        return true;
-      } else {
-        return false;
-      }
-    });
+    return CourseFunctions.invitationCodeExists(title);
   }
 
   void signOut() {
@@ -879,11 +680,12 @@ class LibraryState extends ChangeNotifier {
     _levelListListener = null;
 
     _selectedCourse = null;
-    _isSelectedCourseInitializedFromDb = false;
-    _selectedCourse = null;
+    _availableCourses = [];
+    _publicCourses = [];
     _enrolledPrivateCourses = [];
-    _isCourseListLoaded = false;
-    _isLevelListLoaded = false;
-    _isLessonListLoaded = false;
+    _lessons = null;
+    _levels = null;
+    _isInitialized = false;
+    _initializationCompleter = Completer<void>();
   }
 }

--- a/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
+++ b/lib/ui_foundation/helper_widgets/auto_sign_in_widget.dart
@@ -52,7 +52,7 @@ class AutoSignInWidgetState extends State<AutoSignInWidget> {
       return;
     }
 
-    await libraryState.ensureSelectedCourseLoaded();
+    await libraryState.initialized;
 
     if (libraryState.selectedCourse != null) {
       _isRedirecting = true;

--- a/lib/ui_foundation/helper_widgets/general/course_loading_guard.dart
+++ b/lib/ui_foundation/helper_widgets/general/course_loading_guard.dart
@@ -35,7 +35,7 @@ class _CourseLoadingGuardState extends State<CourseLoadingGuard> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _loadFuture =
-        Provider.of<LibraryState>(context, listen: false).ensureSelectedCourseLoaded();
+        Provider.of<LibraryState>(context, listen: false).initialized;
   }
 
   @override

--- a/lib/ui_foundation/sign_in_page.dart
+++ b/lib/ui_foundation/sign_in_page.dart
@@ -44,7 +44,7 @@ class SignInPage extends StatelessWidget {
                 Provider.of<LibraryState>(context, listen: false);
             if ((await applicationState.currentUserBlocking)?.currentCourseId !=
                 null) {
-              await libraryState.ensureSelectedCourseLoaded();
+              await libraryState.initialized;
               if (libraryState.selectedCourse != null) {
                 Navigator.of(context).pushNamedAndRemoveUntil(
                     NavigationEnum.courseHome.route,


### PR DESCRIPTION
## Summary
- Initialize library state once and expose an `initialized` future
- Load courses and selected course data eagerly and cancel prior listeners on selection changes
- Start library state initialization in the background so landing and sign-in pages render immediately
- Replace `ensureSelectedCourseLoaded` calls with `initialized`
- Encapsulate all Firebase access in helper classes for courses, lessons, levels, and lesson comments

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5c4a8ad8832ea561d9660b712bf5