### PR TITLE
Fix compile errors and align stream subscriptions

### DIFF
--- a/lib/data/data_helpers/course_functions.dart
+++ b/lib/data/data_helpers/course_functions.dart
@@ -12,9 +12,9 @@ class CourseFunctions {
         .collection('courses')
         .where('isPrivate', isEqualTo: false)
         .snapshots()
-        .listen((snapshot) {
-      onData(snapshot.docs.map((e) => Course.fromSnapshot(e)).toList());
-    }, onError: onError);
+        .map((snapshot) =>
+            snapshot.docs.map((e) => Course.fromSnapshot(e)).toList())
+        .listen(onData, onError: onError);
   }
 
   static Future<List<Course>> fetchEnrolledPrivateCourses(

--- a/lib/data/data_helpers/lesson_comment_functions.dart
+++ b/lib/data/data_helpers/lesson_comment_functions.dart
@@ -34,4 +34,4 @@ class LessonCommentFunctions {
       debugPrintStack(stackTrace: stackTrace);
     });
   }
-}1
+}

--- a/lib/data/data_helpers/lesson_functions.dart
+++ b/lib/data/data_helpers/lesson_functions.dart
@@ -16,9 +16,9 @@ class LessonFunctions {
             isEqualTo: FirestoreService.instance.doc(coursePath))
         .orderBy('sortOrder', descending: false)
         .snapshots()
-        .listen((snapshot) {
-      onData(snapshot.docs.map((e) => Lesson.fromSnapshot(e)).toList());
-    });
+        .map((snapshot) =>
+            snapshot.docs.map((e) => Lesson.fromSnapshot(e)).toList())
+        .listen(onData);
   }
 
   static Future<void> setSortOrder(String lessonId, int newSortOrder) {

--- a/lib/data/data_helpers/level_functions.dart
+++ b/lib/data/data_helpers/level_functions.dart
@@ -15,9 +15,9 @@ class LevelFunctions {
             isEqualTo: FirestoreService.instance.doc(coursePath))
         .orderBy('sortOrder', descending: false)
         .snapshots()
-        .listen((snapshot) {
-      onData(snapshot.docs.map((e) => Level.fromQuerySnapshot(e)).toList());
-    });
+        .map((snapshot) =>
+            snapshot.docs.map((e) => Level.fromQuerySnapshot(e)).toList())
+        .listen(onData);
   }
 
   static Future<void> setSortOrder(String levelId, int newSortOrder) {

--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -145,9 +145,11 @@ class LibraryState extends ChangeNotifier {
   }
 
   Future<void> _reloadEnrolledCourses() async {
-    var enrolledCourseIds = _applicationState.currentUser?.enrolledCourseIds;
+    var enrolledCourseRefs = _applicationState.currentUser?.enrolledCourseIds;
 
-    if (enrolledCourseIds != null && enrolledCourseIds.isNotEmpty) {
+    if (enrolledCourseRefs != null && enrolledCourseRefs.isNotEmpty) {
+      final enrolledCourseIds =
+          enrolledCourseRefs.map((ref) => ref.id).toList();
       _enrolledPrivateCourses =
           await CourseFunctions.fetchEnrolledPrivateCourses(enrolledCourseIds);
       _rebuildAvailableCourses();
@@ -644,17 +646,13 @@ class LibraryState extends ChangeNotifier {
 
   addLessonComment(Lesson lesson, String comment) async {
     User user = _applicationState.currentUser!;
-    await LessonCommentFunctions.addComment(
-        lessonId: lesson.id!,
-        userId: user.id,
-        creatorUid: user.uid,
-        text: comment);
+    await LessonCommentFunctions.addLessonComment(lesson, comment, user);
   }
 
   deleteLessonComment(LessonComment comment) async {
     print('Deleting comment: ${comment.id}');
     try {
-      await LessonCommentFunctions.deleteComment(comment.id!);
+      await LessonCommentFunctions.deleteLessonComment(comment);
     } catch (error, stackTrace) {
       print('Failed to delete comment: $error');
       debugPrintStack(stackTrace: stackTrace);


### PR DESCRIPTION
## Summary
- fix lesson comment helpers and remove stray character
- convert Firestore snapshots to typed lists for course, lesson, and level listeners
- adjust library state to pass course IDs and call correct comment helper methods

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b2e52b4832e9ce6d21114963630