### PR TITLE
Write Flutter SDK path to local.properties

### DIFF
--- a/bootstrap_codex.sh
+++ b/bootstrap_codex.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 # 1) make every Gradle wrapper runnable so Codex’s scanner won’t choke
 find . -type f -name "gradlew" -exec chmod +x {} \;
 # 2) guarantee the file Gradle asserts on
-[[ -f android/local.properties ]] || echo "# filled by bootstrap" > android/local.properties
+flutter_sdk="${FLUTTER_HOME:-}"
+if [[ -z "${flutter_sdk}" && -n "$(command -v flutter 2>/dev/null)" ]]; then
+  flutter_sdk="$(dirname "$(dirname "$(command -v flutter)")")"
+fi
+if [[ -n "${flutter_sdk}" ]]; then
+  if [[ -f android/local.properties ]]; then
+    grep -q '^flutter\.sdk=' android/local.properties || echo "flutter.sdk=${flutter_sdk}" >> android/local.properties
+  else
+    echo "flutter.sdk=${flutter_sdk}" > android/local.properties
+  fi
+else
+  [[ -f android/local.properties ]] || touch android/local.properties
+fi
 # 3) hand off to the real (heavy) setup
 exec bash tool/codex_setup.sh


### PR DESCRIPTION
## Summary
- Record the Flutter SDK location in `android/local.properties`, inferring the path from `$FLUTTER_HOME` or the `flutter` command while preserving existing settings.
- Restore `android/settings.gradle` to its original form that asserts the presence of `local.properties` and `flutter.sdk`.

## Testing
- `FLUTTER_HOME="$PWD/fake_flutter" bash bootstrap_codex.sh` (run twice with stub tooling)
- `gradle -p android help` *(fails: Could not resolve all artifacts for configuration 'classpath')*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e6abc18cc832e83c2eed9b67fa5a6