### PR TITLE
Fix belt color interpolation and Firestore doc path

### DIFF
--- a/lib/data/data_helpers/belt_color_functions.dart
+++ b/lib/data/data_helpers/belt_color_functions.dart
@@ -39,13 +39,19 @@ class BeltColorFunctions {
     int lowerIndex = colorIndex.floor();
     int upperIndex = colorIndex.ceil();
 
-    // Calculate the interpolation factor
-    double interpolationFactor =
-        (colorIndex - lowerIndex) * (colors.length - 1);
+    // If the proficiency lines up exactly with a defined color, return it
+    if (lowerIndex == upperIndex) {
+      return colors[lowerIndex];
+    }
+
+    // Calculate the interpolation factor between the two colors.
+    // The factor should be the fractional part of [colorIndex], giving a value
+    // between 0 and 1 for [Color.lerp].
+    final double interpolationFactor = colorIndex - lowerIndex;
 
     // Interpolate between the two colors
-    Color lowerColor = colors[lowerIndex];
-    Color upperColor = colors[upperIndex];
+    final Color lowerColor = colors[lowerIndex];
+    final Color upperColor = colors[upperIndex];
     return Color.lerp(lowerColor, upperColor, interpolationFactor)!;
   }
 }

--- a/lib/data/data_helpers/reference_helper.dart
+++ b/lib/data/data_helpers/reference_helper.dart
@@ -3,4 +3,7 @@ import 'package:social_learning/data/firestore_service.dart';
 
 DocumentReference<Map<String, dynamic>> docRef(
         String collectionName, String docId) =>
-    FirestoreService.instance.doc('/$collectionName/$docId');
+    // The Firebase SDK expects document paths without a leading slash.
+    // Using a leading slash causes lookups to fail when working with
+    // FakeFirebaseFirestore in tests, resulting in "not-found" errors.
+    FirestoreService.instance.doc('$collectionName/$docId');


### PR DESCRIPTION
## Summary
- correct belt color interpolation and handle exact proficiency values
- remove leading slash in reference helper to fix Firestore document lookups

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e6ef8ea24832e91988e837cb4ea70