### PR TITLE
Improve course home layout

### DIFF
--- a/lib/ui_foundation/course_home_page.dart
+++ b/lib/ui_foundation/course_home_page.dart
@@ -28,20 +28,8 @@ class _CourseHomePageState extends State<CourseHomePage> {
     var course = libraryState.selectedCourse;
     return Scaffold(
       appBar: AppBar(
-        title: Text(course?.title ?? ''),
+        title: const Text('Home'),
         actions: [
-          IconButton(
-              onPressed: () {
-                if (course != null) {
-                  showModalBottomSheet(
-                      context: context,
-                      builder: (context) => Padding(
-                            padding: const EdgeInsets.all(16.0),
-                            child: Text(course.description ?? ''),
-                          ));
-                }
-              },
-              icon: const Icon(Icons.info_outline)),
           IconButton(
               onPressed: () {
                 NavigationEnum.home.navigateClean(context);
@@ -55,6 +43,26 @@ class _CourseHomePageState extends State<CourseHomePage> {
           child: CustomUiConstants.framePage(Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              if (course != null) ...[
+                Row(
+                  children: [
+                    Expanded(
+                        child: Text(course.title,
+                            style: CustomTextStyles.headline)),
+                    IconButton(
+                        onPressed: () {
+                          showModalBottomSheet(
+                              context: context,
+                              builder: (context) => Padding(
+                                    padding: const EdgeInsets.all(16.0),
+                                    child: Text(course.description ?? ''),
+                                  ));
+                        },
+                        icon: const Icon(Icons.info_outline))
+                  ],
+                ),
+                const SizedBox(height: 16),
+              ],
               Row(
                 children: const [
                   Expanded(child: ProgressCard()),
@@ -63,7 +71,8 @@ class _CourseHomePageState extends State<CourseHomePage> {
                 ],
               ),
               const SizedBox(height: 16),
-              Text('Recent progress', style: CustomTextStyles.subHeadline),
+              Text('Community activity',
+                  style: CustomTextStyles.subHeadline),
               const SizedBox(height: 8),
               const ProgressVideoFeed(),
             ],

--- a/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
@@ -37,6 +37,11 @@ class NextLessonCard extends StatelessWidget {
           child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child:
+                Text('Next lesson', style: CustomTextStyles.subHeadline),
+          ),
           LessonCoverImageWidget(lesson.coverFireStoragePath),
           Padding(
             padding: const EdgeInsets.all(8.0),

--- a/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
@@ -33,23 +33,33 @@ class ProgressCard extends StatelessWidget {
                   LayoutBuilder(
                     builder: (context, constraints) {
                       double size = constraints.maxWidth;
+                      double strokeWidth = 8;
                       return SizedBox(
                         height: size,
                         width: size,
                         child: Stack(
                           alignment: Alignment.center,
                           children: [
-                            CircularProgressIndicator(
-                              value: progress,
-                              strokeWidth: 8,
-                              valueColor:
-                                  AlwaysStoppedAnimation<Color>(beltColor),
-                              backgroundColor: beltColor.withOpacity(.25),
+                            SizedBox.expand(
+                              child: CircularProgressIndicator(
+                                value: progress,
+                                strokeWidth: strokeWidth,
+                                valueColor:
+                                    AlwaysStoppedAnimation<Color>(beltColor),
+                                backgroundColor: beltColor.withOpacity(.25),
+                              ),
                             ),
-                            Text('$completed of $totalLessons\nlessons completed',
-                                textAlign: TextAlign.center,
-                                style:
-                                    CustomTextStyles.getBody(context))
+                            SizedBox(
+                              width: size - strokeWidth * 2,
+                              height: size - strokeWidth * 2,
+                              child: Center(
+                                child: Text(
+                                    '$completed of $totalLessons\nlessons completed',
+                                    textAlign: TextAlign.center,
+                                    style:
+                                        CustomTextStyles.getBody(context)),
+                              ),
+                            )
                           ],
                         ),
                       );

--- a/lib/ui_foundation/helper_widgets/lesson_cover_image_widget.dart
+++ b/lib/ui_foundation/helper_widgets/lesson_cover_image_widget.dart
@@ -34,7 +34,13 @@ class LessonCoverImageWidgetState extends State<LessonCoverImageWidget> {
           child:
               Image(image: NetworkImage(coverPhotoUrl), fit: BoxFit.contain));
     } else {
-      return const Placeholder();
+      return AspectRatio(
+          aspectRatio: 16 / 9,
+          child: Container(
+              color: Colors.grey[200],
+              child: const Center(
+                  child: Icon(Icons.image_not_supported,
+                      color: Colors.grey))));
     }
   }
 


### PR DESCRIPTION
## Summary
- Handle missing lesson cover image with subtle placeholder
- Enlarge progress circle and keep progress text inside its bounds
- Retitle course home UI and rename activity feed

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e71379cc8832ea72259d984c1d895