### PR TITLE
Use dynamic Firestore getter for tests

### DIFF
--- a/lib/data/data_helpers/course_profile_functions.dart
+++ b/lib/data/data_helpers/course_profile_functions.dart
@@ -4,7 +4,11 @@ import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/course_profile.dart';
 
 class CourseProfileFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Use a getter so tests can override the Firestore instance via
+  // [FirestoreService]. If this were a `final` field it would capture the
+  // default instance at import time and ignore the test override, leading to
+  // "not-found" errors when using [FakeFirebaseFirestore].
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'courseProfiles';
 
   static Future<CourseProfile?> getCourseProfile(String courseId) async {

--- a/lib/data/data_helpers/learning_objective_functions.dart
+++ b/lib/data/data_helpers/learning_objective_functions.dart
@@ -4,7 +4,11 @@ import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/learning_objective.dart';
 
 class LearningObjectiveFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Access Firestore through a getter so that tests can inject a
+  // [FakeFirebaseFirestore] instance. A static `final` field would hold on to
+  // the default instance created at import time and prevent the override,
+  // causing tests to operate on a different database instance.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'learningObjectives';
 
   static Future<List<LearningObjective>> getObjectivesForCourse(

--- a/lib/data/data_helpers/lesson_comment_functions.dart
+++ b/lib/data/data_helpers/lesson_comment_functions.dart
@@ -7,7 +7,9 @@ import 'package:social_learning/data/lesson_comment.dart';
 import 'package:social_learning/data/user.dart';
 
 class LessonCommentFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Use a getter instead of a `final` field so tests can substitute
+  // [FakeFirebaseFirestore] via [FirestoreService].
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
 
   static Future<void> addLessonComment(
       Lesson lesson, String comment, User user) async {

--- a/lib/data/data_helpers/session_plan_activity_functions.dart
+++ b/lib/data/data_helpers/session_plan_activity_functions.dart
@@ -6,7 +6,8 @@ import 'package:social_learning/data/firestore_service.dart';
 import '../session_play_activity_type.dart';
 
 class SessionPlanActivityFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore to allow injecting a fake instance during tests.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'sessionPlanActivities';
 
   /// Create a new activity

--- a/lib/data/data_helpers/session_plan_block_functions.dart
+++ b/lib/data/data_helpers/session_plan_block_functions.dart
@@ -4,7 +4,8 @@ import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/firestore_service.dart';
 
 class SessionPlanBlockFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore so tests can supply a fake instance.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'sessionPlanBlocks';
 
   /// Create a new block under a session plan

--- a/lib/data/data_helpers/session_plan_functions.dart
+++ b/lib/data/data_helpers/session_plan_functions.dart
@@ -4,7 +4,8 @@ import 'package:social_learning/data/session_plan.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 
 class SessionPlanFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore to allow injection of a fake instance in tests.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'sessionPlans';
 
   /// Create a new session plan

--- a/lib/data/data_helpers/teachable_item_category_functions.dart
+++ b/lib/data/data_helpers/teachable_item_category_functions.dart
@@ -5,7 +5,8 @@ import 'package:social_learning/data/teachable_item_category.dart'; // For delet
 import 'package:social_learning/data/firestore_service.dart';
 
 class TeachableItemCategoryFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore so tests can override the instance.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'teachableItemCategories';
   static const String _itemsCollectionPath = 'teachableItems';
 

--- a/lib/data/data_helpers/teachable_item_functions.dart
+++ b/lib/data/data_helpers/teachable_item_functions.dart
@@ -5,7 +5,10 @@ import 'package:social_learning/data/teachable_item_inclusion_status.dart';
 import 'package:social_learning/data/firestore_service.dart';
 
 class TeachableItemFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore so that tests can provide a fake instance via
+  // [FirestoreService]. Keeping a `final` field here would lock in the default
+  // instance at import time and break test isolation.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'teachableItems';
 
   static Future<TeachableItem?> addItem({

--- a/lib/data/data_helpers/teachable_item_tag_functions.dart
+++ b/lib/data/data_helpers/teachable_item_tag_functions.dart
@@ -4,7 +4,8 @@ import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/teachable_item_tag.dart';
 
 class TeachableItemTagFunctions {
-  static final FirebaseFirestore _firestore = FirestoreService.instance;
+  // Getter for Firestore allows injecting fakes in tests.
+  static FirebaseFirestore get _firestore => FirestoreService.instance;
   static const String _collectionPath = 'teachableItemTags';
   static const String _itemsCollectionPath = 'teachableItems';
 

--- a/test/progress_video_functions_test.dart
+++ b/test/progress_video_functions_test.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
 import 'package:social_learning/data/data_helpers/progress_video_functions.dart';
 import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/data/firestore_service.dart';


### PR DESCRIPTION
## Summary
- allow swapping Firebase instances in data helpers by replacing static final fields with getters
- fix progress video tests by importing Flutter widgets

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e729491b8832ea0df439256a54d8d