### PR TITLE
Fix sign-in state so navigation resumes after reauth

### DIFF
--- a/lib/ui_foundation/sign_in_page.dart
+++ b/lib/ui_foundation/sign_in_page.dart
@@ -42,9 +42,9 @@ class SignInPage extends StatelessWidget {
                 Provider.of<ApplicationState>(context, listen: false);
             LibraryState libraryState =
                 Provider.of<LibraryState>(context, listen: false);
-            if ((await applicationState.currentUserBlocking)?.currentCourseId !=
-                null) {
-              await libraryState.initialized;
+            var currentUser = await applicationState.currentUserBlocking;
+            await libraryState.initialize();
+            if (currentUser?.currentCourseId != null) {
               if (libraryState.selectedCourse != null) {
                 Navigator.of(context).pushNamedAndRemoveUntil(
                     NavigationEnum.courseHome.route,


### PR DESCRIPTION
## Summary
- Reset login flag during sign-out to clear authenticated state
- Initialize `LibraryState` on sign-in so course data loads before navigation

## Testing
- `flutter pub get` *(command not found)*
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e71bbb3f4832eaf4e801fd94d6f39