### PR TITLE
Fix progress video test & update fake firestore

### DIFF
--- a/lib/data/data_helpers/progress_video_functions.dart
+++ b/lib/data/data_helpers/progress_video_functions.dart
@@ -30,7 +30,7 @@ class ProgressVideoFunctions {
     return match?.group(1); // Returns the video ID if found, else null
   }
 
-  static void createProgressVideo(
+  static Future<void> createProgressVideo(
       Lesson lesson, User user, String youtubeUrl) async {
     await FirestoreService.instance
         .collection('progressVideos')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -229,10 +229,9 @@ packages:
     dependency: "direct dev"
     description:
       name: fake_cloud_firestore
-      sha256: "804bfb59108fc93b93c28b61e8142c477bd6f188a12d06875310f0b2f01b3974"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.0"
   fake_firebase_security_rules:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
-  fake_cloud_firestore: ^3.1.0
+  fake_cloud_firestore: ^3.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/progress_video_functions_test.dart
+++ b/test/progress_video_functions_test.dart
@@ -92,9 +92,8 @@ void main() {
 
   test('convertAsyncSnapshotToSortedProgressVideos returns empty when null',
       () {
-    final asyncSnapshot =
-        AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>>.withData(
-            ConnectionState.done, null);
+    const asyncSnapshot =
+        AsyncSnapshot<QuerySnapshot<Map<String, dynamic>>>.nothing();
     final videos = ProgressVideoFunctions
         .convertAsyncSnapshotToSortedProgressVideos(asyncSnapshot);
     expect(videos, isEmpty);


### PR DESCRIPTION
## Summary
- fix ProgressVideoFunctions.createProgressVideo to return a Future
- handle null AsyncSnapshot case in progress video tests
- upgrade fake_cloud_firestore dev dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e77221288832eaeae01a632a8fa94