### PR TITLE
Refine course home layout

### DIFF
--- a/lib/ui_foundation/course_home_page.dart
+++ b/lib/ui_foundation/course_home_page.dart
@@ -63,12 +63,15 @@ class _CourseHomePageState extends State<CourseHomePage> {
                 ),
                 const SizedBox(height: 16),
               ],
-              Row(
-                children: const [
-                  Expanded(child: ProgressCard()),
-                  SizedBox(width: 8),
-                  Expanded(child: NextLessonCard()),
-                ],
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: const [
+                    Expanded(child: ProgressCard()),
+                    SizedBox(width: 8, height: double.infinity),
+                    Expanded(child: NextLessonCard()),
+                  ],
+                ),
               ),
               const SizedBox(height: 16),
               Text('Community activity',

--- a/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/next_lesson_card.dart
@@ -36,28 +36,28 @@ class NextLessonCard extends StatelessWidget {
       return Card(
           child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
+          LessonCoverImageWidget(lesson.coverFireStoragePath),
           Padding(
             padding: const EdgeInsets.all(8.0),
             child:
                 Text('Next lesson', style: CustomTextStyles.subHeadline),
           ),
-          LessonCoverImageWidget(lesson.coverFireStoragePath),
           Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child:
                 Text(lesson.title, style: CustomTextStyles.getBody(context)),
           ),
           Align(
-              alignment: Alignment.bottomRight,
+              alignment: Alignment.centerRight,
               child: Padding(
-                  padding: const EdgeInsets.only(right: 8, bottom: 8),
-                  child: ElevatedButton.icon(
+                  padding: const EdgeInsets.only(right: 8, bottom: 8, top: 8),
+                  child: ElevatedButton(
                       onPressed: () =>
                           LessonDetailArgument.goToLessonDetailPage(
                               context, lesson.id!),
-                      icon: const Icon(Icons.play_arrow),
-                      label: const Text('Start'))))
+                      child: const Icon(Icons.play_arrow))))
         ],
       ));
     });

--- a/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
@@ -26,47 +26,46 @@ class ProgressCard extends StatelessWidget {
       Color beltColor = BeltColorFunctions.getBeltColor(progress);
       return Card(
           child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  LayoutBuilder(
-                    builder: (context, constraints) {
-                      double size = constraints.maxWidth;
-                      double strokeWidth = 8;
-                      return SizedBox(
-                        height: size,
-                        width: size,
-                        child: Stack(
-                          alignment: Alignment.center,
-                          children: [
-                            SizedBox.expand(
-                              child: CircularProgressIndicator(
-                                value: progress,
-                                strokeWidth: strokeWidth,
-                                valueColor:
-                                    AlwaysStoppedAnimation<Color>(beltColor),
-                                backgroundColor: beltColor.withOpacity(.25),
-                              ),
-                            ),
-                            SizedBox(
-                              width: size - strokeWidth * 2,
-                              height: size - strokeWidth * 2,
-                              child: Center(
-                                child: Text(
-                                    '$completed of $totalLessons\nlessons completed',
-                                    textAlign: TextAlign.center,
-                                    style:
-                                        CustomTextStyles.getBody(context)),
-                              ),
-                            )
-                          ],
+        padding: const EdgeInsets.all(16),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            double size = constraints.maxWidth;
+            double strokeWidth = 8;
+            return SizedBox.expand(
+              child: Center(
+                child: SizedBox(
+                  height: size,
+                  width: size,
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      SizedBox.expand(
+                        child: CircularProgressIndicator(
+                          value: progress,
+                          strokeWidth: strokeWidth,
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(beltColor),
+                          backgroundColor: beltColor.withOpacity(.25),
                         ),
-                      );
-                    },
+                      ),
+                      SizedBox(
+                        width: size - strokeWidth * 2,
+                        height: size - strokeWidth * 2,
+                        child: Center(
+                          child: Text(
+                              '$completed of $totalLessons\nlessons completed',
+                              textAlign: TextAlign.center,
+                              style: CustomTextStyles.getBody(context)),
+                        ),
+                      )
+                    ],
                   ),
-                ],
-              )));
+                ),
+              ),
+            );
+          },
+        ),
+      ));
     });
   }
 }


### PR DESCRIPTION
## Summary
- Match progress and next lesson cards by stretching row height to the taller card
- Simplify next lesson card layout so image leads and play icon appears without label
- Let the progress card expand vertically, centering the circular indicator with extra space when needed

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e7853abbc832ea6f5c7aa32645550