### PR TITLE
Handle course load errors

### DIFF
--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -84,11 +84,19 @@ class CourseDesignerState extends ChangeNotifier {
 
       _isLoading = true;
       notifyListeners();
-      await _loadDataForCourse(loadId);
-      _activeCourse = selected;
-      _isLoading = false;
-      _isInitialized = true;
-      notifyListeners();
+      try {
+        await _loadDataForCourse(loadId);
+        _activeCourse = selected;
+        _isInitialized = true;
+      } catch (e, st) {
+        debugPrint('Failed to load course data: $e');
+        debugPrint('$st');
+        _activeCourse = null;
+        _isInitialized = false;
+      } finally {
+        _isLoading = false;
+        notifyListeners();
+      }
 
       if (loadId != _libraryState.selectedCourse?.id) {
         _isInitialized = false;


### PR DESCRIPTION
## Summary
- prevent course designer inventory from being stuck on loading spinner when course load fails
- allow re-initialization after a failed course load by not marking the state initialized

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e796afc0c832eafa0993b6110d876