### PR TITLE
Add logging for session plan permission errors

### DIFF
--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -116,13 +116,22 @@ class CourseDesignerState extends ChangeNotifier {
 
   Future<void> _loadDataForCourse(String courseId) async {
     final planFuture = SessionPlanFunctions.getOrCreateSessionPlanForCourse(courseId);
-    final objectivesFuture = LearningObjectiveFunctions.getObjectivesForCourse(courseId);
+    final objectivesFuture =
+        LearningObjectiveFunctions.getObjectivesForCourse(courseId);
     final profileFuture = CourseProfileFunctions.getCourseProfile(courseId);
-    final categoriesFuture = TeachableItemCategoryFunctions.getCategoriesForCourse(courseId);
+    final categoriesFuture =
+        TeachableItemCategoryFunctions.getCategoriesForCourse(courseId);
     final itemsFuture = TeachableItemFunctions.getItemsForCourse(courseId);
     final tagsFuture = TeachableItemTagFunctions.getTagsForCourse(courseId);
 
-    final plan = await planFuture;
+    SessionPlan plan;
+    try {
+      plan = await planFuture;
+    } on FirebaseException catch (e) {
+      print(
+          'Error retrieving session plan for course $courseId: ${e.code} ${e.message}');
+      rethrow;
+    }
 
     final blockAndActivityFutures = await Future.wait([
       SessionPlanBlockFunctions.getBySessionPlan(plan.id!),


### PR DESCRIPTION
## Summary
- Log Firestore session plan queries and creation steps to pinpoint permission issues
- Catch and report session plan retrieval failures in `CourseDesignerState`

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688e7bdf7134832eb3794b67203b0a54