### PR TITLE
test: use mock firestore for learning objectives

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  cloud_firestore_mocks:
+    dependency: "direct dev"
+    description:
+      name: cloud_firestore_mocks
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   fake_firebase_security_rules:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
   fake_cloud_firestore: ^3.1.0
+  cloud_firestore_mocks: ^0.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/learning_objective_functions_test.dart
+++ b/test/learning_objective_functions_test.dart
@@ -1,14 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:social_learning/data/data_helpers/learning_objective_functions.dart';
 import 'package:social_learning/data/firestore_service.dart';
 
 void main() {
-  late FakeFirebaseFirestore fake;
+  late MockFirestoreInstance fake;
 
   setUp(() {
-    fake = FakeFirebaseFirestore();
+    fake = MockFirestoreInstance();
     FirestoreService.instance = fake;
   });
 


### PR DESCRIPTION
## Summary
- restore learning objective helper to use `FieldValue` array operations
- switch learning objective tests to `MockFirestoreInstance` for realistic document reference handling
- add `cloud_firestore_mocks` dev dependency

## Testing
- `flutter pub get` *(command not found: flutter)*
- `flutter analyze` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688e8ae749c0832e807a1608c6244fb3