### PR TITLE
Refine progress card styling

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
@@ -24,7 +24,7 @@ class ProgressCard extends StatelessWidget {
       double progress =
           totalLessons == 0 ? 0 : completed / totalLessons.toDouble();
       Color beltColor = BeltColorFunctions.getBeltColor(progress);
-      const double strokeWidth = 8;
+      const double strokeWidth = 6;
       return Card(
           child: Padding(
         padding: const EdgeInsets.all(16),
@@ -32,8 +32,9 @@ class ProgressCard extends StatelessWidget {
           alignment: Alignment.center,
           fit: StackFit.expand,
           children: [
-            FittedBox(
-              fit: BoxFit.contain,
+            FractionallySizedBox(
+              widthFactor: 0.85,
+              heightFactor: 0.85,
               child: CircularProgressIndicator(
                 value: progress,
                 strokeWidth: strokeWidth,
@@ -42,7 +43,7 @@ class ProgressCard extends StatelessWidget {
               ),
             ),
             Center(
-              child: Text('$completed of $totalLessons\nlessons completed',
+              child: Text('$completed of $totalLessons\nlessons\ncompleted',
                   textAlign: TextAlign.center,
                   style: CustomTextStyles.getBody(context)),
             ),


### PR DESCRIPTION
## Summary
- tweak circular progress width and padding for better layout
- wrap progress text across two lines to avoid overlap

## Testing
- `bash bootstrap_codex.sh` *(fails: xz: (stdin): File format not recognized)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892af5d7950832e98b8dca9577b1f0e