### PR TITLE
Add shared app bars for signed-in and course designer pages

### DIFF
--- a/lib/ui_foundation/cms_detail_page.dart
+++ b/lib/ui_foundation/cms_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
 
 class CmsDetailPage extends StatefulWidget {
@@ -51,9 +52,7 @@ class CmsDetailPageState extends State<CmsDetailPage> {
     }
 
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Social Learning'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Social Learning'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Center(
             child: Container(

--- a/lib/ui_foundation/cms_home_page.dart
+++ b/lib/ui_foundation/cms_home_page.dart
@@ -9,6 +9,7 @@ import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data_support/google_doc_export.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -25,9 +26,7 @@ class CmsHomePageState extends State<CmsHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Social Learning'),
-      ),
+      appBar: const LearningLabAppBar(title: 'Social Learning'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Center(
           child: Container(

--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -7,6 +7,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -107,9 +108,7 @@ class CmsLessonState extends State<CmsLessonPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         floatingActionButton: FloatingActionButton(
             onPressed: () {

--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -6,6 +6,7 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/cms_lesson_page.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/edit_level_title_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/one_time_banner.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
@@ -26,13 +27,13 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title:
-              Consumer<LibraryState>(builder: (context, libraryState, child) {
-            return Text('${libraryState.selectedCourse?.title} Curriculum');
-          }),
-          actions: InstructorNavActions.createActions(context),
-        ),
+        appBar: Consumer<LibraryState>(
+            builder: (context, libraryState, child) {
+          return LearningLabAppBar(
+            title: '${libraryState.selectedCourse?.title} Curriculum',
+            actions: InstructorNavActions.createActions(context),
+          );
+        }),
         bottomNavigationBar: BottomBarV2.build(context),
         floatingActionButton: FloatingActionButton(
           onPressed: () {

--- a/lib/ui_foundation/code_of_conduct_page.dart
+++ b/lib/ui_foundation/code_of_conduct_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
@@ -9,9 +10,7 @@ class CodeOfConductPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Code of Conduct'),
-      ),
+      appBar: const LearningLabAppBar(title: 'Code of Conduct'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_create_page.dart
+++ b/lib/ui_foundation/course_create_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -50,9 +51,7 @@ class CourseCreateState extends State<CourseCreatePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         floatingActionButton: FloatingActionButton(
             backgroundColor: _isFormComplete

--- a/lib/ui_foundation/course_designer_intro_page.dart
+++ b/lib/ui_foundation/course_designer_intro_page.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerIntroPage extends StatefulWidget {
@@ -22,11 +22,8 @@ class _CourseDesignerIntroPageState extends State<CourseDesignerIntroPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Learning Lab'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar:
+          CourseDesignerAppBar(title: 'Learning Lab', scaffoldKey: scaffoldKey),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:social_learning/state/course_designer_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_drag_helper.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_intro_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_card.dart';
@@ -12,7 +13,6 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inv
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 
 class CourseDesignerInventoryPage extends StatefulWidget {
   const CourseDesignerInventoryPage({super.key});
@@ -45,10 +45,8 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
         final entries = _buildEntries(state);
         return Scaffold(
           key: scaffoldKey,
-          appBar: AppBar(
-              title: const Text('Learning Lab'),
-              leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-              actions: InstructorNavActions.createActions(context)),
+          appBar: CourseDesignerAppBar(
+              title: 'Learning Lab', scaffoldKey: scaffoldKey),
           drawer: CourseDesignerDrawer(),
           bottomNavigationBar: BottomBarV2.build(context),
           body: Align(

--- a/lib/ui_foundation/course_designer_learning_objectives_page.dart
+++ b/lib/ui_foundation/course_designer_learning_objectives_page.dart
@@ -14,8 +14,8 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_pre
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_context.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_items_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_overview_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerLearningObjectivesPage extends StatefulWidget {
@@ -84,11 +84,8 @@ class _CourseDesignerLearningObjectivesPageState
 
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Learning Objectives'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar: CourseDesignerAppBar(
+          title: 'Learning Objectives', scaffoldKey: scaffoldKey),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_designer_prerequisites_page.dart
+++ b/lib/ui_foundation/course_designer_prerequisites_page.dart
@@ -8,8 +8,8 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer/dec
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/focused_teachable_item_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_prerequisites/prerequisite_context.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerPrerequisitesPage extends StatefulWidget {
@@ -95,11 +95,8 @@ class _CourseDesignerPrerequisitesPageState
 
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Prerequisites'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar:
+          CourseDesignerAppBar(title: 'Prerequisites', scaffoldKey: scaffoldKey),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_designer_profile_page.dart
+++ b/lib/ui_foundation/course_designer_profile_page.dart
@@ -7,9 +7,9 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerProfilePage extends StatefulWidget {
@@ -120,11 +120,8 @@ class _CourseDesignerProfilePageState extends State<CourseDesignerProfilePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Learning Lab'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar:
+          CourseDesignerAppBar(title: 'Learning Lab', scaffoldKey: scaffoldKey),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_designer_scope_page.dart
+++ b/lib/ui_foundation/course_designer_scope_page.dart
@@ -11,8 +11,8 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_pre
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_context.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_items_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_scope/scope_overview_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerScopePage extends StatefulWidget {
@@ -80,11 +80,8 @@ class _CourseDesignerScopePageState extends State<CourseDesignerScopePage> {
 
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Prerequisites'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar: CourseDesignerAppBar(
+          title: 'Prerequisites', scaffoldKey: scaffoldKey),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_designer_session_plan_page.dart
+++ b/lib/ui_foundation/course_designer_session_plan_page.dart
@@ -4,10 +4,10 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_context.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_plan_overview_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer_session_plan/session_block_list_view.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class CourseDesignerSessionPlanPage extends StatefulWidget {
@@ -79,11 +79,8 @@ class _CourseDesignerSessionPlanPageState
 
     return Scaffold(
       key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('Session Plan'),
-        leading: CourseDesignerDrawer.hamburger(scaffoldKey),
-        actions: InstructorNavActions.createActions(context),
-      ),
+      appBar:
+          CourseDesignerAppBar(title: 'Session Plan', scaffoldKey: scaffoldKey),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(

--- a/lib/ui_foundation/course_generation_page.dart
+++ b/lib/ui_foundation/course_generation_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/data/data_helpers/reference_helper.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -81,7 +82,7 @@ class CourseGenerationPageState extends State<CourseGenerationPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Curriculum Generator')),
+      appBar: const LearningLabAppBar(title: 'Curriculum Generator'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_generation_review_page.dart
+++ b/lib/ui_foundation/course_generation_review_page.dart
@@ -6,6 +6,7 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/data/course_plan.dart';
 import 'package:social_learning/data/data_helpers/course_plan_functions.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 
 class CourseGenerationReviewPage extends StatefulWidget {
@@ -42,7 +43,7 @@ class _CourseGenerationReviewPageState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Generated Course Review')),
+      appBar: const LearningLabAppBar(title: 'Generated Course Review'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_home_page.dart
+++ b/lib/ui_foundation/course_home_page.dart
@@ -5,6 +5,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart'
 import 'package:social_learning/ui_foundation/helper_widgets/course_home/progress_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_home/next_lesson_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_home/progress_video_feed.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -27,16 +28,7 @@ class _CourseHomePageState extends State<CourseHomePage> {
     }
     var course = libraryState.selectedCourse;
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Home'),
-        actions: [
-          IconButton(
-              onPressed: () {
-                NavigationEnum.home.navigateClean(context);
-              },
-              icon: const Icon(Icons.swap_horiz))
-        ],
-      ),
+      appBar: const LearningLabAppBar(title: 'Home'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
           alignment: Alignment.topCenter,

--- a/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
+++ b/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
+import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// App bar used across CourseDesigner pages.
+/// Includes drawer toggle, course switch icon, and instructor navigation icons.
+class CourseDesignerAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final GlobalKey<ScaffoldState> scaffoldKey;
+
+  const CourseDesignerAppBar({
+    super.key,
+    required this.title,
+    required this.scaffoldKey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(title),
+      leading: CourseDesignerDrawer.hamburger(scaffoldKey),
+      actions: [
+        IconButton(
+          onPressed: () => NavigationEnum.home.navigateClean(context),
+          icon: const Icon(Icons.swap_horiz),
+        ),
+        ...InstructorNavActions.createActions(context),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart
+++ b/lib/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// Default app bar for signed-in pages.
+/// Displays a title and a course switching icon.
+class LearningLabAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final List<Widget>? actions;
+
+  const LearningLabAppBar({super.key, required this.title, this.actions});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text(title),
+      actions: [
+        IconButton(
+          onPressed: () => NavigationEnum.home.navigateClean(context),
+          icon: const Icon(Icons.swap_horiz),
+        ),
+        ...?actions,
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/ui_foundation/home_page.dart
+++ b/lib/ui_foundation/home_page.dart
@@ -6,6 +6,7 @@ import 'package:social_learning/data/course.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -43,9 +44,7 @@ class HomePageState extends State<HomePage> {
     // PracticeRecordCourseIdMigration.printPracticeRecordsMissingCourseId();
 
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,

--- a/lib/ui_foundation/instructor_clipboard_page.dart
+++ b/lib/ui_foundation/instructor_clipboard_page.dart
@@ -10,6 +10,7 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_clipboard/instructor_clipboard_header_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_clipboard/instructor_clipboard_table_widget.dart';
 import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
@@ -74,7 +75,7 @@ class _StudentCheckOffState extends State<InstructorClipboardPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Coach’s Clipboard')),
+      appBar: const LearningLabAppBar(title: 'Coach’s Clipboard'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/instructor_dashboard_page.dart
+++ b/lib/ui_foundation/instructor_dashboard_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_roster_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_summary_widget.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
@@ -18,7 +19,7 @@ class InstructorDashboardState extends State<InstructorDashboardPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Learning Lab')),
+      appBar: const LearningLabAppBar(title: 'Learning Lab'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/nearby_mentors_list_widget.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
@@ -108,7 +109,7 @@ class LessonDetailState extends State<LessonDetailPage> {
         var counts = studentState.getCountsForLesson(lesson);
 
             return Scaffold(
-                appBar: AppBar(title: Text('Lesson: ${lesson.title}')),
+                appBar: LearningLabAppBar(title: 'Lesson: ${lesson.title}'),
                 bottomNavigationBar: BottomBarV2.build(context),
                 floatingActionButton: FloatingActionButton(
                   onPressed: () {
@@ -204,7 +205,7 @@ class LessonDetailState extends State<LessonDetailPage> {
           }
 
         return Scaffold(
-            appBar: AppBar(title: const Text('Nothing loaded')),
+            appBar: const LearningLabAppBar(title: 'Nothing loaded'),
             bottomNavigationBar: BottomBarV2.build(context),
             body: const SizedBox.shrink());
       });

--- a/lib/ui_foundation/level_detail_page.dart
+++ b/lib/ui_foundation/level_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
@@ -34,23 +35,23 @@ class LevelDetailState extends State<LevelDetailPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title:
+        appBar:
             Consumer<LibraryState>(builder: (context, libraryState, child) {
-          LevelDetailArgument? argument = ModalRoute.of(context)!
-              .settings
-              .arguments as LevelDetailArgument?;
+          LevelDetailArgument? argument =
+              ModalRoute.of(context)!.settings.arguments as LevelDetailArgument?;
           var levelId = argument?.levelId;
           if (levelId != null) {
             Level? level = libraryState.findLevel(levelId);
             if (level != null) {
               int levelPosition = libraryState.findLevelPosition(level);
-              return Text('Level ${levelPosition + 1}: ${level.title}');
+              return LearningLabAppBar(
+                  title: 'Level ${levelPosition + 1}: ${level.title}');
             }
           } else if (argument?.isFlexLessons == true) {
-            return const Text('Flex Lessons');
+            return const LearningLabAppBar(title: 'Flex Lessons');
           }
-          return const Text('Failed to load');
-        })),
+          return const LearningLabAppBar(title: 'Failed to load');
+        }),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
           alignment: Alignment.topCenter,

--- a/lib/ui_foundation/level_list_page.dart
+++ b/lib/ui_foundation/level_list_page.dart
@@ -7,6 +7,7 @@ import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/level_detail_page.dart';
@@ -25,10 +26,10 @@ class LevelListState extends State<LevelListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title:
-            Consumer<LibraryState>(builder: (context, libraryState, child) {
-          return Text('${libraryState.selectedCourse?.title} Curriculum');
-        })),
+        appBar: Consumer<LibraryState>(builder: (context, libraryState, child) {
+          return LearningLabAppBar(
+              title: '${libraryState.selectedCourse?.title} Curriculum');
+        }),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
           alignment: Alignment.topCenter,

--- a/lib/ui_foundation/online_session_active_page.dart
+++ b/lib/ui_foundation/online_session_active_page.dart
@@ -10,6 +10,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/online_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_widgets/active_online_session_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -25,9 +26,7 @@ class OnlineSessionActiveState extends State<OnlineSessionActivePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Social Learning'),
-      ),
+      appBar: const LearningLabAppBar(title: 'Social Learning'),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _endSession(context),

--- a/lib/ui_foundation/online_session_review_page.dart
+++ b/lib/ui_foundation/online_session_review_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/data/online_session_review.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/online_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/star_rating_widget.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
@@ -146,9 +147,7 @@ class OnlineSessionReviewPageState extends State<OnlineSessionReviewPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Submit Review'),
-      ),
+      appBar: const LearningLabAppBar(title: 'Submit Review'),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
         backgroundColor: _isFormComplete

--- a/lib/ui_foundation/online_session_waiting_room_page.dart
+++ b/lib/ui_foundation/online_session_waiting_room_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/data/online_session.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/online_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -35,9 +36,7 @@ class OnlineSessionWaitingRoomState
           }
         },
         child: Scaffold(
-            appBar: AppBar(
-              title: const Text('Social Learning'),
-            ),
+            appBar: const LearningLabAppBar(title: 'Social Learning'),
             bottomNavigationBar: BottomBarV2.build(context),
             body: Align(
               alignment: Alignment.topCenter,

--- a/lib/ui_foundation/other_profile_page.dart
+++ b/lib/ui_foundation/other_profile_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/data/data_helpers/user_functions.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/expanding_text_box.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_image_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_progress_video_widget.dart';
 import 'package:social_learning/ui_foundation/profile_comparison_page.dart';
@@ -75,9 +76,7 @@ class OtherProfileState extends State<OtherProfilePage> {
     if (otherUser == null) {
       // Loading view.
       return Scaffold(
-          appBar: AppBar(
-            title: const Text('Loading profile...'),
-          ),
+          appBar: const LearningLabAppBar(title: 'Loading profile...'),
           bottomNavigationBar: BottomBarV2.build(context),
           body: Align(
               alignment: Alignment.topCenter,
@@ -93,8 +92,8 @@ class OtherProfileState extends State<OtherProfilePage> {
     } else if (otherUser.isProfilePrivate) {
       // Private profile view
       return Scaffold(
-          appBar: AppBar(
-            title: Text('Profile ${otherUser.displayName}'),
+          appBar: LearningLabAppBar(
+            title: 'Profile ${otherUser.displayName}',
           ),
           bottomNavigationBar: BottomBarV2.build(context),
           body: Align(
@@ -123,9 +122,7 @@ class OtherProfileState extends State<OtherProfilePage> {
 
       // Regular profile view
       return Scaffold(
-          appBar: AppBar(
-            title: Text(otherUser.displayName),
-          ),
+          appBar: LearningLabAppBar(title: otherUser.displayName),
           floatingActionButton: FloatingActionButton(
             child: const Text('Together'),
             onPressed: () {

--- a/lib/ui_foundation/profile_comparison_page.dart
+++ b/lib/ui_foundation/profile_comparison_page.dart
@@ -8,6 +8,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_comparison_table.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_image_by_user_id_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_image_widget.dart';
@@ -68,9 +69,7 @@ class ProfileComparisonState extends State<ProfileComparisonPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,

--- a/lib/ui_foundation/profile_page.dart
+++ b/lib/ui_foundation/profile_page.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:social_learning/data/data_helpers/user_functions.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/enable_location_button.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_lookup_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_progress_video_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/profile_text_editor.dart';
@@ -34,9 +35,7 @@ class ProfilePageState extends State<ProfilePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Social Learning'),
-      ),
+      appBar: const LearningLabAppBar(title: 'Social Learning'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
           alignment: Alignment.topCenter,

--- a/lib/ui_foundation/session_create_page.dart
+++ b/lib/ui_foundation/session_create_page.dart
@@ -4,6 +4,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/organizer_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -23,9 +24,7 @@ class SessionCreateState extends State<SessionCreatePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,

--- a/lib/ui_foundation/session_create_warning_page.dart
+++ b/lib/ui_foundation/session_create_warning_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
@@ -17,9 +18,7 @@ class SessionCreateWarningState extends State<SessionCreateWarningPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
             alignment: Alignment.topCenter,

--- a/lib/ui_foundation/session_home_page.dart
+++ b/lib/ui_foundation/session_home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_widgets/in_person_session_section.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_widgets/online_session_section.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
@@ -17,9 +18,7 @@ class SessionHomePageState extends State<SessionHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Learning Lab'),
-        ),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         bottomNavigationBar: BottomBarV2.build(context),
         body: Align(
           alignment: Alignment.topCenter,

--- a/lib/ui_foundation/session_host_page.dart
+++ b/lib/ui_foundation/session_host_page.dart
@@ -11,6 +11,7 @@ import 'package:social_learning/session_pairing/session_pairing_algorithm.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/organizer_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/lesson_table_cell.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/mentee_table_cell.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/mentor_table_cell.dart';
@@ -32,7 +33,7 @@ class SessionHostState extends State<SessionHostPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text('Learning Lab')),
+        appBar: const LearningLabAppBar(title: 'Learning Lab'),
         floatingActionButton: SpeedDial(
             icon: Icons.more_vert,
             activeIcon: Icons.close,

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -5,6 +5,7 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_round_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
@@ -37,7 +38,7 @@ class SessionStudentState extends State<SessionStudentPage> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Learning Lab')),
+      appBar: const LearningLabAppBar(title: 'Learning Lab'),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,


### PR DESCRIPTION
## Summary
- add `LearningLabAppBar` with course switch action
- add `CourseDesignerAppBar` with drawer toggle and instructor icons
- refactor signed-in pages to use the new shared app bars

## Testing
- `flutter pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894d0fa7504832ea2dd2030ba14fd02