### PR TITLE
Hide lesson cover if none

### DIFF
--- a/lib/ui_foundation/helper_widgets/lesson_cover_image_widget.dart
+++ b/lib/ui_foundation/helper_widgets/lesson_cover_image_widget.dart
@@ -33,25 +33,28 @@ class LessonCoverImageWidgetState extends State<LessonCoverImageWidget> {
           aspectRatio: 16 / 9,
           child:
               Image(image: NetworkImage(coverPhotoUrl), fit: BoxFit.contain));
-    } else {
-      return AspectRatio(
-          aspectRatio: 16 / 9,
-          child: Container(
-              color: Colors.grey[200],
-              child: const Center(
-                  child: Icon(Icons.image_not_supported,
-                      color: Colors.grey))));
     }
+    return const SizedBox.shrink();
   }
 
   Future<void> init() async {
     _lastCoverFireStoragePath = widget.coverFireStoragePath;
     if (widget.coverFireStoragePath != null) {
-      String url = await FirebaseStorage.instance
-          .ref(widget.coverFireStoragePath)
-          .getDownloadURL();
+      try {
+        String url = await FirebaseStorage.instance
+            .ref(widget.coverFireStoragePath)
+            .getDownloadURL();
+        setState(() {
+          _coverPhotoUrl = url;
+        });
+      } catch (_) {
+        setState(() {
+          _coverPhotoUrl = null;
+        });
+      }
+    } else {
       setState(() {
-        _coverPhotoUrl = url;
+        _coverPhotoUrl = null;
       });
     }
   }


### PR DESCRIPTION
## Summary
- Avoid broken image placeholder when a lesson lacks a cover
- Handle Firebase download errors and null covers gracefully

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68966720b7d0832ea511087f3f4ce94b