### PR TITLE
Use PageStorageKey to preserve inventory list scroll

### DIFF
--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -89,7 +89,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
                         itemBuilder: (context, index) {
                           final entry = entries[index];
                           return ReorderableDelayedDragStartListener(
-                            key: ValueKey(entry),
+                            key: PageStorageKey(entry.pageKey),
                             index: index,
                             child: entry.buildWidget(
                               context,

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
@@ -19,6 +19,9 @@ class AddNewCategoryEntry extends InventoryEntry {
   });
 
   @override
+  String get pageKey => 'newCategory';
+
+  @override
   Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
@@ -21,6 +21,9 @@ class AddNewItemEntry extends InventoryEntry {
   });
 
   @override
+  String get pageKey => 'newItem-${category.id!}';
+
+  @override
   Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
     return Container(
       decoration: BoxDecoration(

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_category_entry.dart
@@ -22,6 +22,9 @@ class InventoryCategoryEntry extends InventoryEntry {
       });
 
   @override
+  String get pageKey => 'category-${category.id!}';
+
+  @override
   Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
     return Container(
       margin: CourseDesignerTheme.cardMargin,

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/state/course_designer_state.dart';
 
 abstract class InventoryEntry {
+  /// Unique identifier used as a [PageStorageKey] so Flutter can maintain
+  /// the scroll position of this entry within the inventory list.
+  String get pageKey;
+
   Widget buildWidget(
       BuildContext context, VoidCallback refresh, CourseDesignerState state);
 }

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
@@ -19,6 +19,9 @@ class InventoryItemEntry extends InventoryEntry {
   InventoryItemEntry(this.item, {this.onDelete});
 
   @override
+  String get pageKey => 'item-${item.id!}';
+
+  @override
   Widget buildWidget(
       BuildContext context, VoidCallback refresh, CourseDesignerState state) {
     final allTags = state.tags;


### PR DESCRIPTION
## Summary
- Give each inventory entry a stable `pageKey`
- Use `PageStorageKey` in `CourseDesignerInventoryPage` to maintain scroll position

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f83a39ad4832ebfeee271b27e4db5