### PR TITLE
Warn when closing tag editor with unsaved new tag

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_tag_editor_dialog.dart
@@ -66,7 +66,18 @@ class _InventoryTagEditorDialogState extends State<InventoryTagEditorDialog> {
       ),
       actions: [
         ElevatedButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () {
+            if (_newTagController.text.trim().isNotEmpty) {
+              DialogUtils.showConfirmationDialog(
+                context,
+                'Discard New Tag?',
+                'You have a new tag that has not been added. Exit without creating it?',
+                () => Navigator.of(context).pop(),
+              );
+            } else {
+              Navigator.of(context).pop();
+            }
+          },
           child: const Text('Done'),
         ),
       ],


### PR DESCRIPTION
## Summary
- Warn before closing InventoryTagEditorDialog when a new tag is typed but not added

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f877223cc832eb25cf47c0e4c5f44