### PR TITLE
Fix prerequisite inclusion status persistence

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer_scope/scope_context.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_scope/scope_context.dart
@@ -229,13 +229,7 @@ class ScopeContext {
       }
     }
 
-    // Update in Firebase.
-    TeachableItemFunctions.updateInclusionStatuses(
-      needToSelect,
-      needToDeselect,
-    );
-
-    // Update local context.
+    // Update local context first so the correct state is persisted.
     for (final item in needToSelect) {
       item.inclusionStatus =
           TeachableItemInclusionStatus.includedAsPrerequisite;
@@ -243,6 +237,12 @@ class ScopeContext {
     for (final item in needToDeselect) {
       item.inclusionStatus = TeachableItemInclusionStatus.excluded;
     }
+
+    // Update in Firebase.
+    TeachableItemFunctions.updateInclusionStatuses(
+      needToSelect,
+      needToDeselect,
+    );
   }
 
   List<TeachableItem> getItemsForCategory(String categoryId) {


### PR DESCRIPTION
## Summary
- ensure prerequisite auto-selection updates local status before writing to Firebase so selections persist across reloads

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f9365bec0832e86ac72386de82613