### PR TITLE
Ensure adding teachable item selects it

### DIFF
--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -417,8 +417,22 @@ class CourseDesignerState extends ChangeNotifier {
         learningObjectives[idx] = updated;
       }
       objectiveById[objective.id!] = updated;
-      notifyListeners();
     }
+
+    // Ensure the teachable item is explicitly selected if not already included.
+    if (item.inclusionStatus !=
+            TeachableItemInclusionStatus.explicitlyIncluded &&
+        item.inclusionStatus !=
+            TeachableItemInclusionStatus.includedAsPrerequisite) {
+      item.inclusionStatus =
+          TeachableItemInclusionStatus.explicitlyIncluded;
+      await TeachableItemFunctions.updateInclusionStatus(item);
+      itemById[item.id!] = item;
+      final idx = items.indexWhere((i) => i.id == item.id);
+      if (idx != -1) items[idx] = item;
+    }
+
+    notifyListeners();
   }
 
   Future<void> replaceTeachableItemInObjective({

--- a/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/learning_objectives_context.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_learning_objectives/learning_objectives_context.dart
@@ -175,8 +175,24 @@ class LearningObjectivesContext {
       if (idx != -1) {
         learningObjectives[idx] = updated;
       }
-      refresh();
     }
+
+    // If the teachable item isn't already included, explicitly select it.
+    if (item.inclusionStatus !=
+            TeachableItemInclusionStatus.explicitlyIncluded &&
+        item.inclusionStatus !=
+            TeachableItemInclusionStatus.includedAsPrerequisite) {
+      item.inclusionStatus =
+          TeachableItemInclusionStatus.explicitlyIncluded;
+      await TeachableItemFunctions.updateInclusionStatus(item);
+
+      // Update local caches so UI reflects the change.
+      itemById[item.id!] = item;
+      final itemIdx = items.indexWhere((i) => i.id == item.id);
+      if (itemIdx != -1) items[itemIdx] = item;
+    }
+
+    refresh();
   }
 
   /// Replace [oldItem] with [newItem] on [objective], update cache, refresh UI.

--- a/test/learning_objectives_context_test.dart
+++ b/test/learning_objectives_context_test.dart
@@ -1,0 +1,50 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/data_helpers/learning_objective_functions.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_category_functions.dart';
+import 'package:social_learning/data/data_helpers/teachable_item_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/teachable_item_inclusion_status.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer_learning_objectives/learning_objectives_context.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = null;
+  });
+
+  test('adding item to objective selects item if needed', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final category =
+        await TeachableItemCategoryFunctions.addCategory(courseId: 'c1', name: 'cat');
+    final item = await TeachableItemFunctions.addItem(
+        courseId: 'c1', categoryId: category!.id!, name: 'i1');
+    final objective = await LearningObjectiveFunctions.addObjective(
+        courseId: 'c1', name: 'obj', sortOrder: 0);
+
+    final context = await LearningObjectivesContext.create(
+      courseId: 'c1',
+      refresh: () {},
+    );
+
+    final loadedObj = context.learningObjectives.first;
+    final loadedItem = context.items.first;
+    expect(loadedItem.inclusionStatus, TeachableItemInclusionStatus.excluded);
+
+    await context.addTeachableItemToObjective(
+        objective: loadedObj, item: loadedItem);
+
+    expect(context.learningObjectives.first.teachableItemRefs.length, 1);
+    expect(loadedItem.inclusionStatus,
+        TeachableItemInclusionStatus.explicitlyIncluded);
+    final fetched = await TeachableItemFunctions.getItemById(loadedItem.id!);
+    expect(fetched?.inclusionStatus,
+        TeachableItemInclusionStatus.explicitlyIncluded);
+  });
+}


### PR DESCRIPTION
## Summary
- Auto-select teachable items when added to a learning objective if not previously included
- Keep state caches updated and persist inclusion status change
- Cover behavior with a new test

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fab834150832e9d8b7df7610addd8