### PR TITLE
feat: add custom drag handles to inventory

### DIFF
--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -84,13 +84,13 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
                             oldIndex: oldIndex,
                             newIndex: newIndex,
                           );
+                          await state.getItemsWithDependencies();
                           setState(() {});
                         },
                         itemBuilder: (context, index) {
                           final entry = entries[index];
-                          return ReorderableDelayedDragStartListener(
+                          return KeyedSubtree(
                             key: PageStorageKey(entry.pageKey),
-                            index: index,
                             child: entry.buildWidget(
                               context,
                               () {
@@ -100,6 +100,7 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
                                 setState(() {});
                               },
                               state,
+                              index,
                             ),
                           );
                         },

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_category_entry.dart
@@ -22,7 +22,8 @@ class AddNewCategoryEntry extends InventoryEntry {
   String get pageKey => 'newCategory';
 
   @override
-  Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
+  Widget buildWidget(
+      BuildContext context, VoidCallback refresh, CourseDesignerState _, int _) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
       child: Row(

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/add_new_item_entry.dart
@@ -34,7 +34,8 @@ class AddNewItemEntry extends InventoryEntry {
   String get pageKey => 'newItem-${category.id!}';
 
   @override
-  Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
+  Widget buildWidget(
+      BuildContext context, VoidCallback refresh, CourseDesignerState _, int _) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_focusCategoryId == category.id) {
         focusNode.requestFocus();

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_category_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_category_entry.dart
@@ -25,7 +25,8 @@ class InventoryCategoryEntry extends InventoryEntry {
   String get pageKey => 'category-${category.id!}';
 
   @override
-  Widget buildWidget(BuildContext context, VoidCallback refresh, CourseDesignerState _) {
+  Widget buildWidget(
+      BuildContext context, VoidCallback refresh, CourseDesignerState _, int index) {
     return Container(
       margin: CourseDesignerTheme.cardMargin,
       decoration: BoxDecoration(
@@ -38,6 +39,12 @@ class InventoryCategoryEntry extends InventoryEntry {
         padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
         child: Row(
           children: [
+            // Drag handle
+            ReorderableDragStartListener(
+              index: index,
+              child: const Icon(Icons.drag_handle, color: Colors.grey, size: 18),
+            ),
+            const SizedBox(width: 8),
             // Expand/collapse icon with ripple
             Padding(
               padding: const EdgeInsets.only(right: 8.0),

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_entry.dart
@@ -7,5 +7,9 @@ abstract class InventoryEntry {
   String get pageKey;
 
   Widget buildWidget(
-      BuildContext context, VoidCallback refresh, CourseDesignerState state);
+    BuildContext context,
+    VoidCallback refresh,
+    CourseDesignerState state,
+    int index,
+  );
 }

--- a/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_inventory/inventory_item_entry.dart
@@ -23,7 +23,7 @@ class InventoryItemEntry extends InventoryEntry {
 
   @override
   Widget buildWidget(
-      BuildContext context, VoidCallback refresh, CourseDesignerState state) {
+      BuildContext context, VoidCallback refresh, CourseDesignerState state, int index) {
     final allTags = state.tags;
     final assignedTagIds =
     (item.tagIds ?? []).map((ref) => ref.path).toSet();
@@ -45,13 +45,22 @@ class InventoryItemEntry extends InventoryEntry {
         ),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),
-      child: Wrap(
-        crossAxisAlignment: WrapCrossAlignment.center,
-        spacing: 6,
-        runSpacing: 6,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(item.name ?? '(Unnamed)',
-              style: CustomTextStyles.getBody(context)),
+          ReorderableDragStartListener(
+            index: index,
+            child: const Icon(Icons.drag_handle, color: Colors.grey, size: 18),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                Text(item.name ?? '(Unnamed)',
+                    style: CustomTextStyles.getBody(context)),
 
           if (item.notes?.trim().isNotEmpty ?? false)
             _icon(context, Icons.notes, () {
@@ -91,7 +100,7 @@ class InventoryItemEntry extends InventoryEntry {
               );
             }),
 
-          ...assignedTags.map((tag) => InkWell(
+                ...assignedTags.map((tag) => InkWell(
             onTap: () {
               DialogUtils.showConfirmationDialog(
                 context,
@@ -124,8 +133,8 @@ class InventoryItemEntry extends InventoryEntry {
             ),
           )),
 
-          if (availableTags.isNotEmpty)
-            TagFanoutWidget(
+                if (availableTags.isNotEmpty)
+                  TagFanoutWidget(
               availableTags: availableTags,
               onTagSelected: (tag) async {
                 final tagRef = docRef('teachableItemTags', tag.id!);
@@ -148,7 +157,10 @@ class InventoryItemEntry extends InventoryEntry {
 
                 refresh();
               },
+                  ),
+              ],
             ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add ReorderableDragStartListener handles to category and item entries
- refresh inventory list after reorder to reflect Firebase updates

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb9798334832eb48496bfebfe1311