### PR TITLE
feat: make session activity times drag handles

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
@@ -67,6 +67,7 @@ class DecomposedCourseDesignerCard {
     required Widget child,
     required Color color,
     String? leadingText,
+    int? dragHandleIndex,
   }) {
     final Color backgroundColor = color.withAlpha((0.08 * 255).round());  // subtle tint
     final Color leadingBackgroundColor = color.withAlpha((0.18 * 255).round());  // stronger tint
@@ -82,23 +83,11 @@ class DecomposedCourseDesignerCard {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             if (leadingText != null)
-              Container(
-                width: 48,
-                decoration: BoxDecoration(
-                  color: leadingBackgroundColor,
-                  border: Border(
-                    right: BorderSide(color: color, width: 1.2),
-                  ),
-                ),
-                alignment: Alignment.center,
-                child: Text(
-                  leadingText,
-                  style: const TextStyle(
-                    // fontSize: 13,
-                    fontWeight: FontWeight.w500,
-                    color: Colors.black87,
-                  ),
-                ),
+              _buildLeadingBox(
+                leadingText,
+                color,
+                leadingBackgroundColor,
+                dragHandleIndex,
               ),
             Expanded(
               child: Padding(
@@ -110,6 +99,37 @@ class DecomposedCourseDesignerCard {
         ),
       ),
     );
+  }
+
+  static Widget _buildLeadingBox(
+    String text,
+    Color color,
+    Color backgroundColor,
+    int? dragHandleIndex,
+  ) {
+    Widget box = Container(
+      width: 48,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border(
+          right: BorderSide(color: color, width: 1.2),
+        ),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontWeight: FontWeight.w500,
+          color: Colors.black87,
+        ),
+      ),
+    );
+
+    if (dragHandleIndex != null) {
+      box = ReorderableDragStartListener(index: dragHandleIndex, child: box);
+    }
+
+    return box;
   }
 
 

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/lesson_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/lesson_activity_row.dart
@@ -10,12 +10,14 @@ import '../course_designer/decomposed_course_designer_card.dart';
 class LessonActivityRow extends StatelessWidget {
   final SessionPlanActivity activity;
   final SessionPlanContext sessionPlanContext;
+  final int reorderIndex;
   final LayerLink _layerLink = LayerLink();
 
   LessonActivityRow({
     super.key,
     required this.activity,
     required this.sessionPlanContext,
+    required this.reorderIndex,
   });
 
   int _getDefaultDuration() {
@@ -100,6 +102,7 @@ class LessonActivityRow extends StatelessWidget {
     return DecomposedCourseDesignerCard.buildColorHighlightedBody(
       color: color,
       leadingText: time,
+      dragHandleIndex: reorderIndex,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
         child: Row(

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/non_lesson_activity_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/non_lesson_activity_row.dart
@@ -7,11 +7,13 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer_ses
 class NonLessonActivityRow extends StatelessWidget {
   final SessionPlanActivity activity;
   final SessionPlanContext sessionPlanContext;
+  final int reorderIndex;
 
   const NonLessonActivityRow({
     super.key,
     required this.activity,
     required this.sessionPlanContext,
+    required this.reorderIndex,
   });
 
   @override
@@ -28,6 +30,7 @@ class NonLessonActivityRow extends StatelessWidget {
     return DecomposedCourseDesignerCard.buildColorHighlightedBody(
       color: color,
       leadingText: startTime,
+      dragHandleIndex: reorderIndex,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 8.0),
         child: Row(

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_header_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_header_row.dart
@@ -8,11 +8,13 @@ import '../value_input_dialog.dart';
 class SessionBlockHeaderRow extends StatelessWidget {
   final SessionPlanBlock block;
   final SessionPlanContext contextData;
+  final int reorderIndex;
 
   const SessionBlockHeaderRow({
     super.key,
     required this.block,
     required this.contextData,
+    required this.reorderIndex,
   });
 
   void _editBlockName(BuildContext context) {
@@ -73,9 +75,14 @@ class SessionBlockHeaderRow extends StatelessWidget {
       ),
     ];
 
-    return DecomposedCourseDesignerCard.buildHeaderWithIcons(
+    final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
       block.name ?? '(Untitled)',
       actions,
+    );
+
+    return ReorderableDragStartListener(
+      index: reorderIndex,
+      child: header,
     );
   }
 }

--- a/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_list_view.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer_session_plan/session_block_list_view.dart
@@ -17,62 +17,61 @@ class SessionBlocksListView extends StatelessWidget {
   Widget build(BuildContext context) {
     final blocks = sessionPlanContext.blocks;
 
-    var children = [
-      for (final block in blocks) ...[
-        SessionBlockHeaderRow(
-          key: ValueKey('block_${block.id}'),
-          block: block,
-          contextData: sessionPlanContext,
-        ),
+    final List<Widget> children = [];
+    final List<String> keys = [];
+    int index = 0;
 
-        for (final activity in sessionPlanContext.getActivitiesForBlock(block.id!))
-          if (activity.activityType == SessionPlanActivityType.lesson)
-            LessonActivityRow(
-              key: ValueKey('activity_${activity.id}'),
-              activity: activity,
-              sessionPlanContext: sessionPlanContext,
-            )
-          else
-            NonLessonActivityRow(
-              key: ValueKey('activity_${activity.id}'),
-              activity: activity,
-              sessionPlanContext: sessionPlanContext,
-            ),
+    for (final block in blocks) {
+      children.add(SessionBlockHeaderRow(
+        key: ValueKey('block_${block.id}'),
+        block: block,
+        contextData: sessionPlanContext,
+        reorderIndex: index,
+      ));
+      keys.add('block_${block.id}');
+      index++;
 
-        AddActivityRow(
-          key: ValueKey('add_activity_${block.id}'),
-          sessionPlanBlockId: block.id!,
-          sessionPlanContext: sessionPlanContext,
-        )
-      ],
+      for (final activity in sessionPlanContext.getActivitiesForBlock(block.id!)) {
+        if (activity.activityType == SessionPlanActivityType.lesson) {
+          children.add(LessonActivityRow(
+            key: ValueKey('activity_${activity.id}'),
+            activity: activity,
+            sessionPlanContext: sessionPlanContext,
+            reorderIndex: index,
+          ));
+        } else {
+          children.add(NonLessonActivityRow(
+            key: ValueKey('activity_${activity.id}'),
+            activity: activity,
+            sessionPlanContext: sessionPlanContext,
+            reorderIndex: index,
+          ));
+        }
+        keys.add('activity_${activity.id}');
+        index++;
+      }
 
-      AddBlockRow(
-          key: ValueKey('add_block'),
-          sessionPlanContext: sessionPlanContext),
-    ];
+      children.add(AddActivityRow(
+        key: ValueKey('add_activity_${block.id}'),
+        sessionPlanBlockId: block.id!,
+        sessionPlanContext: sessionPlanContext,
+      ));
+      keys.add('add_activity_${block.id}');
+      index++;
+    }
 
-    final keys = children.map((e) => (e.key as ValueKey).value as String).toList();
-
-    // return ReorderableListView.builder(
-    //   buildDefaultDragHandles: false,
-    //   padding: EdgeInsets.zero,
-    //   onReorder: (fromIndex, toIndex) => _handleReorder(keys[fromIndex], keys[toIndex]),
-    //   children: children,
-    // );
+    children.add(AddBlockRow(
+      key: const ValueKey('add_block'),
+      sessionPlanContext: sessionPlanContext,
+    ));
+    keys.add('add_block');
 
     return ReorderableListView.builder(
-      buildDefaultDragHandles: false,        // <- turn off auto handle
+      buildDefaultDragHandles: false, // handles provided manually
       itemCount: children.length,
-      itemBuilder: (context, index) {
-        final child = children[index];
-
-        return ReorderableDragStartListener(
-          key: child.key,
-          index: index,                      // index of the item
-          child: child
-        );
-      },
-      onReorder: (fromIndex, toIndex) => _handleReorder(keys[fromIndex], keys[toIndex]),
+      itemBuilder: (context, index) => children[index],
+      onReorder: (fromIndex, toIndex) =>
+          _handleReorder(keys[fromIndex], keys[toIndex]),
     );
 
   }


### PR DESCRIPTION
## Summary
- enable optional drag handle support in DecomposedCourseDesignerCard
- use activity start time box as drag handle in session plan rows
- manage reorder indices inside SessionBlocksListView for custom handles

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff3d6841c832ead93436e2521dd11