### PR TITLE
Add course designer tab bar navigation

### DIFF
--- a/lib/ui_foundation/course_designer_intro_page.dart
+++ b/lib/ui_foundation/course_designer_intro_page.dart
@@ -22,8 +22,10 @@ class _CourseDesignerIntroPageState extends State<CourseDesignerIntroPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      appBar:
-          CourseDesignerAppBar(title: 'Learning Lab', scaffoldKey: scaffoldKey),
+      appBar: CourseDesignerAppBar(
+          title: 'Learning Lab',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerIntro),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
@@ -31,7 +33,7 @@ class _CourseDesignerIntroPageState extends State<CourseDesignerIntroPage> {
           NavigationEnum.courseDesignerProfile.navigateCleanDelayed(context);
         }, // or Icons.navigate_next
         tooltip: 'Next Page',
-        child: Icon(Icons.arrow_forward),
+        child: const Icon(Icons.arrow_forward),
       ),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_designer_inventory_page.dart
+++ b/lib/ui_foundation/course_designer_inventory_page.dart
@@ -47,15 +47,18 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
         return Scaffold(
           key: scaffoldKey,
           appBar: CourseDesignerAppBar(
-              title: 'Learning Lab', scaffoldKey: scaffoldKey),
+              title: 'Learning Lab',
+              scaffoldKey: scaffoldKey,
+              currentNav: NavigationEnum.courseDesignerInventory),
           drawer: CourseDesignerDrawer(),
           bottomNavigationBar: BottomBarV2.build(context),
           floatingActionButton: FloatingActionButton(
             onPressed: () {
-              NavigationEnum.courseDesignerPrerequisites.navigateCleanDelayed(context);
+              NavigationEnum.courseDesignerPrerequisites
+                  .navigateCleanDelayed(context);
             }, // or Icons.navigate_next
             tooltip: 'Next Page',
-            child: Icon(Icons.arrow_forward),
+            child: const Icon(Icons.arrow_forward),
           ),
           body: Align(
             alignment: Alignment.topCenter,
@@ -95,7 +98,8 @@ class CourseDesignerInventoryState extends State<CourseDesignerInventoryPage> {
                               context,
                               () {
                                 if (entry is InventoryCategoryEntry) {
-                                  _expanded[entry.category.id!] = entry.isExpanded;
+                                  _expanded[entry.category.id!] =
+                                      entry.isExpanded;
                                 }
                                 setState(() {});
                               },

--- a/lib/ui_foundation/course_designer_learning_objectives_page.dart
+++ b/lib/ui_foundation/course_designer_learning_objectives_page.dart
@@ -83,15 +83,18 @@ class _CourseDesignerLearningObjectivesPageState
     return Scaffold(
       key: scaffoldKey,
       appBar: CourseDesignerAppBar(
-          title: 'Learning Objectives', scaffoldKey: scaffoldKey),
+          title: 'Learning Objectives',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerLearningObjectives),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          NavigationEnum.courseDesignerSessionPlan.navigateCleanDelayed(context);
+          NavigationEnum.courseDesignerSessionPlan
+              .navigateCleanDelayed(context);
         },
         tooltip: 'Next Page',
-        child: Icon(Icons.arrow_forward),
+        child: const Icon(Icons.arrow_forward),
       ),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_designer_prerequisites_page.dart
+++ b/lib/ui_foundation/course_designer_prerequisites_page.dart
@@ -94,8 +94,10 @@ class _CourseDesignerPrerequisitesPageState
 
     return Scaffold(
       key: scaffoldKey,
-      appBar:
-          CourseDesignerAppBar(title: 'Prerequisites', scaffoldKey: scaffoldKey),
+      appBar: CourseDesignerAppBar(
+          title: 'Prerequisites',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerPrerequisites),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
@@ -103,7 +105,7 @@ class _CourseDesignerPrerequisitesPageState
           NavigationEnum.courseDesignerScope.navigateCleanDelayed(context);
         }, // or Icons.navigate_next
         tooltip: 'Next Page',
-        child: Icon(Icons.arrow_forward),
+        child: const Icon(Icons.arrow_forward),
       ),
       body: Align(
         alignment: Alignment.topCenter,
@@ -122,7 +124,7 @@ class _CourseDesignerPrerequisitesPageState
     );
   }
 
-  Widget _buildMainContent() {
+    Widget _buildMainContent() {
       return NestedScrollView(
         headerSliverBuilder: (context, innerBoxIsScrolled) {
           return [
@@ -142,13 +144,12 @@ class _CourseDesignerPrerequisitesPageState
               ),
             ),
           ];
-        },body:
-PrerequisitesCard(
-            context: _prerequisiteContext!,
-            focusedItem: _focusedItem,
-  onSelectItem: _handleFocusItemSelected,
-          ),
-        );
-
-  }
+        },
+        body: PrerequisitesCard(
+          context: _prerequisiteContext!,
+          focusedItem: _focusedItem,
+          onSelectItem: _handleFocusItemSelected,
+        ),
+      );
+    }
 }

--- a/lib/ui_foundation/course_designer_profile_page.dart
+++ b/lib/ui_foundation/course_designer_profile_page.dart
@@ -105,95 +105,100 @@ class _CourseDesignerProfilePageState extends State<CourseDesignerProfilePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      appBar:
-          CourseDesignerAppBar(title: 'Learning Lab', scaffoldKey: scaffoldKey),
+      appBar: CourseDesignerAppBar(
+          title: 'Learning Lab',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerProfile),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
         onPressed: _save,
         child: const Icon(Icons.save),
       ),
-      body: Consumer<CourseDesignerState>(builder: (context, courseDesignerState, _) {
-
-        return courseDesignerState.status != CourseDesignerStateStatus.initialized
+      body: Consumer<CourseDesignerState>(
+          builder: (context, courseDesignerState, _) {
+        return courseDesignerState.status !=
+                CourseDesignerStateStatus.initialized
             ? const Center(child: CircularProgressIndicator())
             : Align(
-          alignment: Alignment.topCenter,
-          child: CustomUiConstants.framePage(
-            enableScrolling: true,
-            enableCreatorGuard: true,
-            enableCourseLoadingGuard: true,
-            // Inside the build method:
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                CourseDesignerCard(
-                    title: 'Step 1: Course Profile',
-                    body: Text(
-                      'Get clear on the course context and guide the AI to support you effectively.',
-                      style: CustomTextStyles.getBody(context),
-                    )),
-                _buildCard('Course Details', [
-                  _field(
-                    context,
-                    'Course topic & focus',
-                    'What is the course about? What key topics or skills will you focus on?',
-                    topicController,
+                alignment: Alignment.topCenter,
+                child: CustomUiConstants.framePage(
+                  enableScrolling: true,
+                  enableCreatorGuard: true,
+                  enableCourseLoadingGuard: true,
+                  // Inside the build method:
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      CourseDesignerCard(
+                          title: 'Step 1: Course Profile',
+                          body: Text(
+                            'Get clear on the course context and guide the AI to support you effectively.',
+                            style: CustomTextStyles.getBody(context),
+                          )),
+                      _buildCard('Course Details', [
+                        _field(
+                          context,
+                          'Course topic & focus',
+                          'What is the course about? What key topics or skills will you focus on?',
+                          topicController,
+                        ),
+                        _field(
+                          context,
+                          'Schedule & duration',
+                          'E.g. one-time 3-hour workshop or 6 weekly 90-minute classes.',
+                          scheduleController,
+                        ),
+                      ]),
+                      _buildCard('Audience & Format', [
+                        _field(
+                          context,
+                          'Who is it for?',
+                          'Describe who typically joins, even if you say it’s for “everyone.” What are their backgrounds, goals, or quirks?',
+                          audienceController,
+                        ),
+                        _field(
+                          context,
+                          'Group size & format',
+                          'E.g. 1–5 students, lots of new people each week. Lecture or hands-on?',
+                          groupFormatController,
+                        ),
+                      ]),
+                      _buildCard('Location & Joining', [
+                        _field(
+                          context,
+                          'Location',
+                          'E.g. Midtown NYC studio, classroom, park, Zoom…',
+                          locationController,
+                        ),
+                        _field(
+                          context,
+                          'How do students join?',
+                          'E.g. \$15 per class, first class free, bring yoga mat…',
+                          joinInfoController,
+                        ),
+                      ]),
+                      _buildCard('Tone & Notes', [
+                        _field(
+                          context,
+                          'Tone & teaching approach',
+                          'Describe your teaching style. What matters to you when teaching this course?',
+                          toneController,
+                        ),
+                        _field(
+                          context,
+                          'Anything unusual or worth noting?',
+                          'E.g. multilingual students, final recital, outdoor setting, no consistent group…',
+                          notesController,
+                        ),
+                      ]),
+                    ],
                   ),
-                  _field(
-                    context,
-                    'Schedule & duration',
-                    'E.g. one-time 3-hour workshop or 6 weekly 90-minute classes.',
-                    scheduleController,
-                  ),
-                ]),
-                _buildCard('Audience & Format', [
-                  _field(
-                    context,
-                    'Who is it for?',
-                    'Describe who typically joins, even if you say it’s for “everyone.” What are their backgrounds, goals, or quirks?',
-                    audienceController,
-                  ),
-                  _field(
-                    context,
-                    'Group size & format',
-                    'E.g. 1–5 students, lots of new people each week. Lecture or hands-on?',
-                    groupFormatController,
-                  ),
-                ]),
-                _buildCard('Location & Joining', [
-                  _field(
-                    context,
-                    'Location',
-                    'E.g. Midtown NYC studio, classroom, park, Zoom…',
-                    locationController,
-                  ),
-                  _field(
-                    context,
-                    'How do students join?',
-                    'E.g. \$15 per class, first class free, bring yoga mat…',
-                    joinInfoController,
-                  ),
-                ]),
-                _buildCard('Tone & Notes', [
-                  _field(
-                    context,
-                    'Tone & teaching approach',
-                    'Describe your teaching style. What matters to you when teaching this course?',
-                    toneController,
-                  ),
-                  _field(
-                    context,
-                    'Anything unusual or worth noting?',
-                    'E.g. multilingual students, final recital, outdoor setting, no consistent group…',
-                    notesController,
-                  ),
-                ]),
-              ],
-            ),
-          ),
-        );}));
-      }
+                ),
+              );
+      }),
+    );
+  }
 
   Widget _buildCard(String title, List<Widget> fields) {
     return CourseDesignerCard(

--- a/lib/ui_foundation/course_designer_scope_page.dart
+++ b/lib/ui_foundation/course_designer_scope_page.dart
@@ -79,7 +79,9 @@ class _CourseDesignerScopePageState extends State<CourseDesignerScopePage> {
     return Scaffold(
       key: scaffoldKey,
       appBar: CourseDesignerAppBar(
-          title: 'Scoping', scaffoldKey: scaffoldKey),
+          title: 'Scoping',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerScope),
       drawer: CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
@@ -88,7 +90,7 @@ class _CourseDesignerScopePageState extends State<CourseDesignerScopePage> {
               .navigateCleanDelayed(context);
         },
         tooltip: 'Next Page',
-        child: Icon(Icons.arrow_forward),
+        child: const Icon(Icons.arrow_forward),
       ),
       body: Align(
         alignment: Alignment.topCenter,

--- a/lib/ui_foundation/course_designer_session_plan_page.dart
+++ b/lib/ui_foundation/course_designer_session_plan_page.dart
@@ -79,8 +79,10 @@ class _CourseDesignerSessionPlanPageState
 
     return Scaffold(
       key: scaffoldKey,
-      appBar:
-          CourseDesignerAppBar(title: 'Session Plan', scaffoldKey: scaffoldKey),
+      appBar: CourseDesignerAppBar(
+          title: 'Session Plan',
+          scaffoldKey: scaffoldKey,
+          currentNav: NavigationEnum.courseDesignerSessionPlan),
       drawer: const CourseDesignerDrawer(),
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
@@ -99,9 +101,9 @@ class _CourseDesignerSessionPlanPageState
           enableCourseLoadingGuard: true,
           _sessionPlanContext == null
               ? const Padding(
-            padding: EdgeInsets.all(32.0),
-            child: CircularProgressIndicator(),
-          )
+                  padding: EdgeInsets.all(32.0),
+                  child: CircularProgressIndicator(),
+                )
               : _buildMainContent(),
         ),
       ),

--- a/lib/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// Tab bar for navigating the Course Designer flow.
+/// Each tab represents a page; tapping navigates to that page without
+/// providing swipeable tab views.
+class CourseDesignerTabBar extends StatefulWidget implements PreferredSizeWidget {
+  final NavigationEnum currentNav;
+
+  const CourseDesignerTabBar({super.key, required this.currentNav});
+
+  static const List<_TabInfo> _tabs = [
+    _TabInfo(
+        icon: Icons.info_outline,
+        nav: NavigationEnum.courseDesignerIntro,
+        label: 'Intro'),
+    _TabInfo(
+        icon: Icons.person_outline,
+        nav: NavigationEnum.courseDesignerProfile,
+        label: 'Profile'),
+    _TabInfo(
+        icon: Icons.lightbulb_outline,
+        nav: NavigationEnum.courseDesignerInventory,
+        label: 'Inventory'),
+    _TabInfo(
+        icon: Icons.account_tree_outlined,
+        nav: NavigationEnum.courseDesignerPrerequisites,
+        label: 'Prerequisites'),
+    _TabInfo(
+        icon: Icons.shopping_cart_outlined,
+        nav: NavigationEnum.courseDesignerScope,
+        label: 'Scoping'),
+    _TabInfo(
+        icon: Icons.flag_outlined,
+        nav: NavigationEnum.courseDesignerLearningObjectives,
+        label: 'Objectives'),
+    _TabInfo(
+        icon: Icons.schedule_outlined,
+        nav: NavigationEnum.courseDesignerSessionPlan,
+        label: 'Session Plan'),
+  ];
+
+  /// Returns the tab index for a [NavigationEnum].
+  static int indexFromNav(NavigationEnum nav) {
+    return _tabs.indexWhere((t) => t.nav == nav);
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
+
+  @override
+  State<CourseDesignerTabBar> createState() => _CourseDesignerTabBarState();
+}
+
+class _CourseDesignerTabBarState extends State<CourseDesignerTabBar>
+    with SingleTickerProviderStateMixin {
+  late final TabController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TabController(
+      length: CourseDesignerTabBar._tabs.length,
+      vsync: this,
+      initialIndex: CourseDesignerTabBar.indexFromNav(widget.currentNav),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant CourseDesignerTabBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.currentNav != widget.currentNav) {
+      _controller.index = CourseDesignerTabBar.indexFromNav(widget.currentNav);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      controller: _controller,
+      tabs: [
+        for (final t in CourseDesignerTabBar._tabs)
+          Tab(icon: Tooltip(message: t.label, child: Icon(t.icon))),
+      ],
+      onTap: (i) {
+        final nav = CourseDesignerTabBar._tabs[i].nav;
+        if (nav != widget.currentNav) {
+          nav.navigateClean(context);
+        }
+      },
+    );
+  }
+}
+
+class _TabInfo {
+  final IconData icon;
+  final NavigationEnum nav;
+  final String label;
+
+  const _TabInfo({required this.icon, required this.nav, required this.label});
+}
+

--- a/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
+++ b/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
@@ -8,11 +9,13 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 class CourseDesignerAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final GlobalKey<ScaffoldState> scaffoldKey;
+  final NavigationEnum? currentNav;
 
   const CourseDesignerAppBar({
     super.key,
     required this.title,
     required this.scaffoldKey,
+    this.currentNav,
   });
 
   @override
@@ -27,9 +30,13 @@ class CourseDesignerAppBar extends StatelessWidget implements PreferredSizeWidge
         ),
         ...InstructorNavActions.createActions(context),
       ],
+      bottom: currentNav == null
+          ? null
+          : CourseDesignerTabBar(currentNav: currentNav!),
     );
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => Size.fromHeight(
+      kToolbarHeight + (currentNav == null ? 0 : kTextTabBarHeight));
 }


### PR DESCRIPTION
## Summary
- Let `CourseDesignerTabBar` manage its own `TabController` and navigate on tap
- Drop `DefaultTabController` wrappers so each CourseDesigner page simply builds a `Scaffold`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11e9ebce4832e90bf79b4e1c3ac83