### PR TITLE
Fix course switch after creating new course

### DIFF
--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -467,7 +467,12 @@ class LibraryState extends ChangeNotifier {
     var course = Course.fromDocument(await docRef.get());
 
     // Automatically enroll the creator in their own course.
-    _applicationState.enrollInPrivateCourse(course);
+    await _applicationState.enrollInPrivateCourse(course);
+
+    // Reload courses and switch to the newly created course.
+    await _reloadEnrolledCourses();
+    selectedCourse =
+        _availableCourses.firstWhereOrNull((element) => element.id == course.id);
 
     return course;
   }


### PR DESCRIPTION
## Summary
- Ensure selected course updates when a private course is created
- Reload courses and await enrollment before returning

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 15466 issues found)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a12647b480832e937f95e35d4045c3