### PR TITLE
Add skill rubric and assessment data classes

### DIFF
--- a/lib/data/skill_assessment.dart
+++ b/lib/data/skill_assessment.dart
@@ -1,0 +1,81 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SkillAssessment {
+  final String? id;
+  final DocumentReference courseId;
+  final String studentUid;
+  final String instructorUid;
+  final String? notes;
+  final List<SkillAssessmentDimension> dimensions;
+  final Timestamp createdAt;
+  final Timestamp modifiedAt;
+
+  SkillAssessment({
+    this.id,
+    required this.courseId,
+    required this.studentUid,
+    required this.instructorUid,
+    this.notes,
+    required this.dimensions,
+    required this.createdAt,
+    required this.modifiedAt,
+  });
+
+  factory SkillAssessment.fromSnapshot(
+      DocumentSnapshot<Map<String, dynamic>> snapshot) {
+    final data = snapshot.data()!;
+    return SkillAssessment(
+      id: snapshot.id,
+      courseId: data['courseId'] as DocumentReference,
+      studentUid: data['studentUid'] as String,
+      instructorUid: data['instructorUid'] as String,
+      notes: data['notes'] as String?,
+      dimensions: (data['dimensions'] as List<dynamic>? ?? [])
+          .map((e) =>
+              SkillAssessmentDimension.fromMap(e as Map<String, dynamic>))
+          .toList(),
+      createdAt: data['createdAt'] as Timestamp,
+      modifiedAt: data['modifiedAt'] as Timestamp,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'courseId': courseId,
+        'studentUid': studentUid,
+        'instructorUid': instructorUid,
+        'notes': notes,
+        'dimensions': dimensions.map((e) => e.toMap()).toList(),
+        'createdAt': createdAt,
+        'modifiedAt': modifiedAt,
+      };
+}
+
+class SkillAssessmentDimension {
+  final String id;
+  final String name;
+  final int degree;
+  final int maxDegrees;
+
+  SkillAssessmentDimension({
+    required this.id,
+    required this.name,
+    required this.degree,
+    required this.maxDegrees,
+  });
+
+  factory SkillAssessmentDimension.fromMap(Map<String, dynamic> data) =>
+      SkillAssessmentDimension(
+        id: data['id'] as String,
+        name: data['name'] as String,
+        degree: data['degree'] as int,
+        maxDegrees: data['maxDegrees'] as int,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'degree': degree,
+        'maxDegrees': maxDegrees,
+      };
+}
+

--- a/lib/data/skill_rubric.dart
+++ b/lib/data/skill_rubric.dart
@@ -1,0 +1,103 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SkillRubric {
+  final String? id;
+  final DocumentReference courseId;
+  final List<SkillDimension> dimensions;
+  final Timestamp createdAt;
+  final Timestamp modifiedAt;
+
+  SkillRubric({
+    this.id,
+    required this.courseId,
+    required this.dimensions,
+    required this.createdAt,
+    required this.modifiedAt,
+  });
+
+  factory SkillRubric.fromSnapshot(
+      DocumentSnapshot<Map<String, dynamic>> snapshot) {
+    final data = snapshot.data()!;
+    return SkillRubric(
+      id: snapshot.id,
+      courseId: data['courseId'] as DocumentReference,
+      dimensions: (data['dimensions'] as List<dynamic>? ?? [])
+          .map((e) => SkillDimension.fromMap(e as Map<String, dynamic>))
+          .toList(),
+      createdAt: data['createdAt'] as Timestamp,
+      modifiedAt: data['modifiedAt'] as Timestamp,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'courseId': courseId,
+        'dimensions': dimensions.map((e) => e.toMap()).toList(),
+        'createdAt': createdAt,
+        'modifiedAt': modifiedAt,
+      };
+}
+
+class SkillDimension {
+  final String id;
+  final String name;
+  final String? description;
+  final List<SkillDegree> degrees;
+
+  SkillDimension({
+    required this.id,
+    required this.name,
+    this.description,
+    required this.degrees,
+  });
+
+  factory SkillDimension.fromMap(Map<String, dynamic> data) => SkillDimension(
+        id: data['id'] as String,
+        name: data['name'] as String,
+        description: data['description'] as String?,
+        degrees: (data['degrees'] as List<dynamic>? ?? [])
+            .map((e) => SkillDegree.fromMap(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'degrees': degrees.map((e) => e.toMap()).toList(),
+      };
+}
+
+class SkillDegree {
+  final String id;
+  final int degree;
+  final String name;
+  final String? description;
+  final List<DocumentReference> lessonRefs;
+
+  SkillDegree({
+    required this.id,
+    required this.degree,
+    required this.name,
+    this.description,
+    required this.lessonRefs,
+  });
+
+  factory SkillDegree.fromMap(Map<String, dynamic> data) => SkillDegree(
+        id: data['id'] as String,
+        degree: data['degree'] as int,
+        name: data['name'] as String,
+        description: data['description'] as String?,
+        lessonRefs: (data['lessonRefs'] as List<dynamic>? ?? [])
+            .map((ref) => ref as DocumentReference)
+            .toList(),
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'degree': degree,
+        'name': name,
+        'description': description,
+        'lessonRefs': lessonRefs,
+      };
+}
+


### PR DESCRIPTION
## Summary
- add `SkillRubric` model with nested `SkillDimension` and `SkillDegree` classes
- add `SkillAssessment` model to record student evaluations
- rename `SkillAxis` to `SkillDimension` for consistent terminology

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a366751f5c832e92bbd56379aa07cc