### PR TITLE
feat: store latest course assessments on user

### DIFF
--- a/lib/data/user.dart
+++ b/lib/data/user.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/skill_assessment.dart';
 
 class User {
   String id;
@@ -15,6 +16,7 @@ class User {
   DocumentReference? currentCourseId;
   bool isProfilePrivate;
   List<CourseProficiency>? courseProficiencies;
+  List<CourseSkillAssessment>? courseSkillAssessments;
   bool isGeoLocationEnabled;
   GeoPoint? location;
   GeoPoint? roughUserLocation;
@@ -38,6 +40,7 @@ class User {
       this.currentCourseId,
       this.isProfilePrivate,
       this.courseProficiencies,
+      this.courseSkillAssessments,
       this.isGeoLocationEnabled,
       this.location,
       this.roughUserLocation,
@@ -69,6 +72,17 @@ class User {
                   CourseProficiency(doc['courseId'], doc['proficiency'])
               ]
             : [],
+        courseSkillAssessments = (e.data()?['courseSkillAssessments']) != null
+            ? [
+                for (var doc in e.data()?['courseSkillAssessments'])
+                  CourseSkillAssessment(
+                      doc['courseId'] as DocumentReference,
+                      (doc['dimensions'] as List<dynamic>? ?? [])
+                          .map((e) => SkillAssessmentDimension.fromMap(
+                              e as Map<String, dynamic>))
+                          .toList())
+              ]
+            : [],
         isGeoLocationEnabled = e.data()?['isGeoLocationEnabled'] ?? false,
         location = e.data()?['location'],
         roughUserLocation = e.data()?['roughUserLocation'],
@@ -79,6 +93,11 @@ class User {
 
   CourseProficiency? getCourseProficiency(Course course) {
     return courseProficiencies
+        ?.firstWhereOrNull((element) => element.courseId.id == course.id);
+  }
+
+  CourseSkillAssessment? getCourseSkillAssessment(Course course) {
+    return courseSkillAssessments
         ?.firstWhereOrNull((element) => element.courseId.id == course.id);
   }
 
@@ -96,4 +115,11 @@ class CourseProficiency {
   double proficiency;
 
   CourseProficiency(this.courseId, this.proficiency);
+}
+
+class CourseSkillAssessment {
+  DocumentReference courseId;
+  List<SkillAssessmentDimension> dimensions;
+
+  CourseSkillAssessment(this.courseId, this.dimensions);
 }

--- a/lib/session_pairing/testing/organizer_session_state_mock.dart
+++ b/lib/session_pairing/testing/organizer_session_state_mock.dart
@@ -56,6 +56,7 @@ class OrganizerSessionStateMock extends OrganizerSessionState {
         null,
         false,
         null,
+        null,
         false,
         null,
         null,

--- a/test/progress_video_functions_test.dart
+++ b/test/progress_video_functions_test.dart
@@ -71,7 +71,7 @@ void main() {
     final lesson = Lesson('l1', courseRef, null, 0, 't', null, '', null, null,
         null, null, null, null, '', null);
     final user = User('u1', 'uid1', '', '', null, '', false, null, null, null,
-        false, null, false, null, null, null, null, null,
+        false, null, null, false, null, null, null, null, null,
         Timestamp.fromMillisecondsSinceEpoch(0));
 
     await ProgressVideoFunctions.createProgressVideo(


### PR DESCRIPTION
## Summary
- extend `User` model with per-course `CourseSkillAssessment` data
- parse course skill assessments and expose lookup helper
- adjust tests and mocks for new field

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36cd9cce4832e918efa4d4537991b