### PR TITLE
Fix lesson status comparison

### DIFF
--- a/lib/state/student_state.dart
+++ b/lib/state/student_state.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/Level.dart';
@@ -150,7 +151,7 @@ class StudentState extends ChangeNotifier {
       var teachRecords = _teachRecords;
       if (teachRecords != null) {
         for (PracticeRecord record in teachRecords) {
-          if (record.lessonId == lesson.id) {
+          if (record.lessonId.id == lesson.id) {
             if (record.isGraduation) {
               hasTaught = true;
               break;
@@ -273,6 +274,12 @@ class StudentState extends ChangeNotifier {
     }
 
     return lessonCount;
+  }
+
+  @visibleForTesting
+  void setPracticeRecords({List<PracticeRecord>? learnRecords, List<PracticeRecord>? teachRecords}) {
+    _learnRecords = learnRecords;
+    _teachRecords = teachRecords;
   }
 
   void signOut() {

--- a/test/student_state_test.dart
+++ b/test/student_state_test.dart
@@ -1,0 +1,70 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/lesson.dart';
+import 'package:social_learning/data/practice_record.dart';
+import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/state/student_state.dart';
+
+class _FakeApplicationState extends ApplicationState {
+  @override
+  Future<void> init() async {}
+}
+
+void main() {
+  test('getLessonStatus returns 3 when lesson taught', () {
+    final fakeFirestore = FakeFirebaseFirestore();
+    final appState = _FakeApplicationState();
+    final libraryState = LibraryState(appState);
+    final studentState = StudentState(appState, libraryState);
+
+    final lessonRef = fakeFirestore.doc('lessons/l1');
+    final courseRef = fakeFirestore.doc('courses/c1');
+    final lesson = Lesson(
+      'l1',
+      courseRef,
+      null,
+      0,
+      'title',
+      null,
+      'instructions',
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      'creator',
+      [],
+    );
+
+    final learnRecord = PracticeRecord(
+      'r1',
+      lessonRef,
+      courseRef,
+      'u1',
+      'u2',
+      true,
+      null,
+      null,
+    );
+    final teachRecord = PracticeRecord(
+      'r2',
+      lessonRef,
+      courseRef,
+      'u3',
+      'u2',
+      true,
+      null,
+      null,
+    );
+
+    studentState.setPracticeRecords(
+      learnRecords: [learnRecord],
+      teachRecords: [teachRecord],
+    );
+
+    expect(studentState.getLessonStatus(lesson), 3);
+  });
+}
+


### PR DESCRIPTION
## Summary
- Compare lesson IDs correctly when checking if a lesson was taught
- Expose test hook to inject practice records for StudentState
- Add test ensuring `getLessonStatus` returns taught status

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4f155d5ec832ebe2b57113c3fea3c