### PR TITLE
feat: enhance profile glow with shader effects

### DIFF
--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_glow_painter.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_glow_painter.dart
@@ -1,0 +1,42 @@
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+
+/// Paints a rising-sun style glow around a circular avatar using a custom
+/// fragment shader. The shader renders a non-linear 1/x halo with a
+/// white→yellow→orange color ramp, a dark contrast ring, and optional sun
+/// flares whose intensity grows with [glowStrength].
+class ProfileGlowPainter extends CustomPainter {
+  final double avatarRadius;
+  final double glowStrength; // 0.0 - 1.0
+
+  static ui.FragmentProgram? _program;
+
+  /// Loads the fragment program if it hasn't been loaded yet.
+  static Future<void> ensureShader() async {
+    _program ??=
+        await ui.FragmentProgram.fromAsset('shaders/profile_glow.frag');
+  }
+
+  const ProfileGlowPainter({
+    required this.avatarRadius,
+    required this.glowStrength,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (_program == null) return;
+    final shader = _program!.fragmentShader()
+      ..setFloat(0, size.width)
+      ..setFloat(1, size.height)
+      ..setFloat(2, avatarRadius)
+      ..setFloat(3, glowStrength);
+
+    canvas.drawRect(Offset.zero & size, Paint()..shader = shader);
+  }
+
+  @override
+  bool shouldRepaint(covariant ProfileGlowPainter oldDelegate) {
+    return oldDelegate.avatarRadius != avatarRadius ||
+        oldDelegate.glowStrength != glowStrength;
+  }
+}

--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_glow_renderer.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_glow_renderer.dart
@@ -1,0 +1,67 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'profile_glow_painter.dart';
+
+/// Renders a profile avatar with a progress belt and a rising-sun style glow.
+///
+/// This class focuses purely on drawing. It accepts the pieces required for
+/// rendering and produces a [ui.Image] that callers can cache or paint into the
+/// widget tree.
+class ProfileGlowRenderer {
+  final ui.Image avatar;
+  final double avatarDiameter;
+  final double beltWidth;
+  final Color beltColor;
+  final double teachLearnRatio;
+
+  const ProfileGlowRenderer({
+    required this.avatar,
+    required this.avatarDiameter,
+    required this.beltWidth,
+    required this.beltColor,
+    this.teachLearnRatio = 0.0,
+  });
+
+  /// Draws the avatar, belt, and glow to an off-screen canvas and returns the
+  /// resulting image.
+  Future<ui.Image> render() async {
+    final double radius = avatarDiameter / 2;
+    final double padding = 24; // space for glow
+    final double canvasSize = avatarDiameter + padding * 2;
+    final Offset center = Offset(canvasSize / 2, canvasSize / 2);
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder, Rect.fromLTWH(0, 0, canvasSize, canvasSize));
+
+    final double ratio = ((teachLearnRatio - 0.5) / 0.5).clamp(0.0, 1.0);
+    if (ratio > 0) {
+      await ProfileGlowPainter.ensureShader();
+      ProfileGlowPainter(
+        avatarRadius: radius,
+        glowStrength: ratio,
+      ).paint(canvas, Size(canvasSize, canvasSize));
+    }
+
+    // Draw avatar
+    final avatarRect = Rect.fromCircle(center: center, radius: radius);
+    final srcRect =
+        Rect.fromLTWH(0, 0, avatar.width.toDouble(), avatar.height.toDouble());
+    canvas.save();
+    canvas.clipPath(Path()..addOval(avatarRect));
+    canvas.drawImageRect(avatar, srcRect, avatarRect, Paint());
+    canvas.restore();
+
+    // Draw belt ring
+    final beltPaint = Paint()
+      ..color = beltColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = beltWidth;
+    canvas.drawCircle(center, radius + beltWidth / 2, beltPaint);
+
+    final picture = recorder.endRecording();
+    return picture.toImage(canvasSize.ceil(), canvasSize.ceil());
+  }
+
+}
+

--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_image_v3.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_image_v3.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/data/user.dart';
+import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/other_profile_page.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/profile_glow_painter.dart';
+
+/// Unified version of [ProfileImageWidget] and [ProfileImageByUserIdWidget].
+///
+/// Displays a user's profile image with an optional belt-colored border and can
+/// link to the user's profile page. The widget can be constructed either with a
+/// [User] object or a Firestore document reference to the user. All Firebase
+/// calls are delegated to [UserFunctions].
+class ProfileImageV3 extends StatefulWidget {
+  final User? _user;
+  final DocumentReference? _userRef;
+  final double? maxRadius;
+  final bool linkToOtherProfile;
+  final bool listenForProfileUpdate;
+  final bool _useCurrentUser;
+  final double teachLearnRatio;
+
+  const ProfileImageV3._(this._user, this._userRef,
+      {super.key,
+      this.maxRadius,
+      this.linkToOtherProfile = false,
+      this.listenForProfileUpdate = false,
+      bool useCurrentUser = false,
+      this.teachLearnRatio = 0.0})
+      : _useCurrentUser = useCurrentUser;
+
+  /// Creates a [ProfileImageV3] from an existing [User] object.
+  factory ProfileImageV3.fromUser(User user,
+      {Key? key,
+      double? maxRadius,
+      bool linkToOtherProfile = false,
+      bool listenForProfileUpdate = false,
+      double teachLearnRatio = 0.0}) {
+    return ProfileImageV3._(user, null,
+        key: key,
+        maxRadius: maxRadius,
+        linkToOtherProfile: linkToOtherProfile,
+        listenForProfileUpdate: listenForProfileUpdate,
+        teachLearnRatio: teachLearnRatio);
+  }
+
+  /// Creates a [ProfileImageV3] from a user document reference.
+  factory ProfileImageV3.fromUserId(DocumentReference userRef,
+      {Key? key,
+      double? maxRadius,
+      bool linkToOtherProfile = false,
+      bool listenForProfileUpdate = false,
+      double teachLearnRatio = 0.0}) {
+    return ProfileImageV3._(null, userRef,
+        key: key,
+        maxRadius: maxRadius,
+        linkToOtherProfile: linkToOtherProfile,
+        listenForProfileUpdate: listenForProfileUpdate,
+        teachLearnRatio: teachLearnRatio);
+  }
+
+  /// Creates a [ProfileImageV3] for the currently logged-in user.
+  factory ProfileImageV3.fromCurrentUser(
+      {Key? key,
+      double? maxRadius,
+      bool linkToOtherProfile = false,
+      bool listenForProfileUpdate = false,
+      double teachLearnRatio = 0.0}) {
+    return ProfileImageV3._(null, null,
+        key: key,
+        maxRadius: maxRadius,
+        linkToOtherProfile: linkToOtherProfile,
+        listenForProfileUpdate: listenForProfileUpdate,
+        useCurrentUser: true,
+        teachLearnRatio: teachLearnRatio);
+  }
+
+  @override
+  State<ProfileImageV3> createState() => _ProfileImageV3State();
+}
+
+class _ProfileImageV3State extends State<ProfileImageV3> {
+  User? _user;
+  String? _profilePhotoUrl;
+  StreamSubscription<User>? _userSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    ProfileGlowPainter.ensureShader().then((_) {
+      if (mounted) setState(() {});
+    });
+    _init();
+  }
+
+  @override
+  void dispose() {
+    _userSubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _init() async {
+    if (widget._useCurrentUser) {
+      final applicationState =
+          Provider.of<ApplicationState>(context, listen: false);
+      User? currentUser = applicationState.currentUser;
+      currentUser ??= await applicationState.currentUserBlocking;
+      if (currentUser != null) {
+        _updateUser(currentUser);
+        if (widget.listenForProfileUpdate) {
+          _userSubscription =
+              UserFunctions.listenToUser(currentUser.id).listen(_updateUser);
+        }
+      }
+    } else if (widget._user != null) {
+      _updateUser(widget._user!);
+      if (widget.listenForProfileUpdate) {
+        _userSubscription = UserFunctions.listenToUser(widget._user!.id)
+            .listen(_updateUser);
+      }
+    } else if (widget._userRef != null) {
+      if (widget.listenForProfileUpdate) {
+        _userSubscription =
+            UserFunctions.listenToUser(widget._userRef!.id).listen(_updateUser);
+      } else {
+        User user = await UserFunctions.getUserById(widget._userRef!.id);
+        _updateUser(user);
+      }
+    }
+  }
+
+  void _updateUser(User user) {
+    _user = user;
+    _loadProfilePhoto();
+  }
+
+  Future<void> _loadProfilePhoto() async {
+    if (_user == null) return;
+    String? url = await UserFunctions.getProfilePhotoUrl(_user!);
+    if (mounted) {
+      setState(() {
+        _profilePhotoUrl = url;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      final libraryState = Provider.of<LibraryState>(context);
+      final borderColor = _computeBorderColor(libraryState);
+      final maxDisplayRadius = _calculateDisplayRadius(constraints);
+      Widget avatar;
+      if (_profilePhotoUrl != null) {
+        avatar = _buildAvatarWithImage(context, borderColor, maxDisplayRadius,
+            constraints.maxWidth);
+      } else {
+        avatar = CircleAvatar(
+          maxRadius: maxDisplayRadius,
+          child: Icon(Icons.photo, size: maxDisplayRadius),
+        );
+      }
+
+      final glowRatio = widget.teachLearnRatio;
+      if (glowRatio > 0.5) {
+        final glowStrength = ((glowRatio - 0.5) / 0.5).clamp(0.0, 1.0);
+        final glowExtent = maxDisplayRadius * (0.5 * glowStrength);
+        avatar = Stack(
+          alignment: Alignment.center,
+          children: [
+            SizedBox(
+              width: (maxDisplayRadius + glowExtent) * 2,
+              height: (maxDisplayRadius + glowExtent) * 2,
+              child: CustomPaint(
+                painter: ProfileGlowPainter(
+                    avatarRadius: maxDisplayRadius,
+                    glowStrength: glowStrength),
+              ),
+            ),
+            avatar,
+          ],
+        );
+      }
+
+      if (widget.linkToOtherProfile) {
+        return InkWell(onTap: _goToOtherProfile, child: avatar);
+      }
+      return avatar;
+    });
+  }
+
+  double _calculateDisplayRadius(BoxConstraints constraints) {
+    final availableWidth = constraints.maxWidth.isFinite
+        ? constraints.maxWidth
+        : MediaQuery.of(context).size.width;
+    final unconstrainedRadius = availableWidth / 2;
+    final maxRadius = widget.maxRadius;
+    if (maxRadius == null) {
+      return unconstrainedRadius;
+    }
+    return maxRadius < unconstrainedRadius ? maxRadius : unconstrainedRadius;
+  }
+
+  Widget _buildAvatarWithImage(BuildContext context, Color? borderColor,
+      double maxDisplayRadius, double availableWidth) {
+    Widget avatar = _createCircleAvatar(context, maxDisplayRadius, availableWidth);
+
+    if (borderColor != null) {
+      avatar = Container(
+          decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: borderColor, width: 2.0)),
+          child: avatar);
+    }
+    return avatar;
+  }
+
+  CircleAvatar _createCircleAvatar(
+      BuildContext context, double maxDisplayRadius, double availableWidth) {
+    final pixelRatio = MediaQuery.of(context).devicePixelRatio;
+    final screenPhysicalWidth =
+        MediaQuery.of(context).size.width * pixelRatio * 0.34;
+    final displayDiameter = maxDisplayRadius * 2;
+    final physicalWidth = displayDiameter * pixelRatio;
+    final resizeWidth =
+        physicalWidth < screenPhysicalWidth ? physicalWidth : screenPhysicalWidth;
+
+    return CircleAvatar(
+      backgroundImage: ResizeImage(NetworkImage(_profilePhotoUrl!),
+          width: resizeWidth.toInt(), policy: ResizeImagePolicy.fit),
+      maxRadius: maxDisplayRadius,
+    );
+  }
+
+  Color? _computeBorderColor(LibraryState libraryState) {
+    final user = _user;
+    final course = libraryState.selectedCourse;
+    if (user != null && course != null) {
+      final courseProficiency = user.getCourseProficiency(course);
+      if (courseProficiency != null) {
+        return BeltColorFunctions.getBeltColor(courseProficiency.proficiency);
+      }
+    }
+    return null;
+  }
+
+  void _goToOtherProfile() {
+    final user = _user;
+    if (user != null) {
+      OtherProfileArgument.goToOtherProfile(context, user.id, user.uid);
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,9 @@ flutter:
     - assets/covers/
     - assets/icons/
 
+  shaders:
+    - shaders/profile_glow.frag
+
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware
 

--- a/shaders/profile_glow.frag
+++ b/shaders/profile_glow.frag
@@ -1,0 +1,62 @@
+#version 100
+precision mediump float;
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 uResolution;
+uniform float uAvatarRadius;
+uniform float uGlowStrength;
+
+half4 main(vec2 fragCoord) {
+  float strength = clamp(uGlowStrength, 0.0, 1.0);
+  if (strength <= 0.0) {
+    return vec4(0.0);
+  }
+
+  vec2 center = uResolution * 0.5;
+  vec2 uv = (fragCoord - center) / uAvatarRadius;
+
+  // Sun center rises toward the top-right as strength increases.
+  vec2 sunCenter = vec2(0.35, mix(0.3, -0.35, strength));
+  float sunRadius = 0.18;
+
+  float planetDist = length(uv);
+  float sunDist = length(uv - sunCenter);
+
+  // 1/x-style halo fade
+  float halo = 1.0 / (1.0 + 10.0 * max(sunDist - sunRadius, 0.0));
+
+  // rim highlight hugging the avatar edge
+  float rimWidth = 0.02 + 0.08 * strength;
+  float rim = (1.0 - smoothstep(1.0, 1.0 + rimWidth, planetDist)) * step(1.0, planetDist);
+
+  // Angular mask so the glow mainly appears near the sun
+  float dir = dot(normalize(uv), normalize(sunCenter));
+  float arcMask = smoothstep(-0.4, 1.0, dir);
+
+  // Base color transitions: white -> yellow -> orange -> black
+  vec3 white = vec3(1.0);
+  vec3 yellow = vec3(1.0, 0.9, 0.5);
+  vec3 orange = vec3(1.0, 0.6, 0.2);
+  vec3 black = vec3(0.0);
+
+  float d = sunDist - sunRadius;
+  vec3 color = white;
+  color = mix(color, yellow, smoothstep(0.0, 0.1, d));
+  color = mix(color, orange, smoothstep(0.1, 0.25, d));
+  color = mix(color, black, smoothstep(0.25, 0.6, d));
+
+  // Dark contrast ring for visibility on light backgrounds
+  float darkRing = (1.0 - smoothstep(1.02, 1.15, planetDist)) * arcMask;
+  color = mix(color, black, darkRing);
+
+  // Sun flares
+  float angle = atan(uv.y - sunCenter.y, uv.x - sunCenter.x);
+  float flare = pow(max(0.0, cos(angle * 8.0)), 32.0);
+  flare *= smoothstep(sunRadius, sunRadius + 0.5, sunDist);
+  color += vec3(1.0, 0.8, 0.3) * flare * strength;
+  halo += flare * 0.2 * strength;
+
+  float alpha = halo * rim * arcMask;
+  return vec4(color, alpha);
+}


### PR DESCRIPTION
## Summary
- extend fragment shader with yellow-orange color ramp, dark contrast ring, and sun flares for rising-sun profile glow
- render glow via shader in `ProfileGlowRenderer` and apply when teach/learn ratio exceeds 0.5
- guard async shader load with `mounted` check in `ProfileImageV2`
- add `ProfileImageV3` using the glow shader while restoring `ProfileImageV2` to its original behavior

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4bbe7492c832eb46c507542ab24df