### PR TITLE
feat: add skill rubric list view

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_degree_row.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+
+class NewSkillDegreeRow extends StatefulWidget {
+  final SkillDimension dimension;
+  final CourseDesignerState state;
+
+  const NewSkillDegreeRow({
+    super.key,
+    required this.dimension,
+    required this.state,
+  });
+
+  @override
+  State<NewSkillDegreeRow> createState() => _NewSkillDegreeRowState();
+}
+
+class _NewSkillDegreeRowState extends State<NewSkillDegreeRow> {
+  final TextEditingController _controller = TextEditingController();
+
+  Future<void> _add() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    await widget.state.addSkillDegree(widget.dimension.id, text);
+    _controller.clear();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecomposedCourseDesignerCard.buildBody(
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                decoration: CustomUiConstants.getFilledInputDecoration(
+                  context,
+                  labelText: 'Add new degree...',
+                  enabledColor: Colors.grey.shade400,
+                ),
+                onSubmitted: (_) => _add(),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.add_circle_outline, size: 20),
+              onPressed: _add,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_dimension_row.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+
+class NewSkillDimensionRow extends StatefulWidget {
+  final CourseDesignerState state;
+
+  const NewSkillDimensionRow({super.key, required this.state});
+
+  @override
+  State<NewSkillDimensionRow> createState() => _NewSkillDimensionRowState();
+}
+
+class _NewSkillDimensionRowState extends State<NewSkillDimensionRow> {
+  final TextEditingController _controller = TextEditingController();
+
+  Future<void> _add() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    await widget.state.addSkillDimension(text);
+    _controller.clear();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        DecomposedCourseDesignerCard.buildHeader('Add new dimension'),
+        DecomposedCourseDesignerCard.buildBody(
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: CustomUiConstants.getFilledInputDecoration(
+                      context,
+                      labelText: 'Dimension name',
+                      enabledColor: Colors.grey.shade400,
+                    ),
+                    onSubmitted: (_) => _add(),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add_circle_outline, size: 20),
+                  onPressed: _add,
+                ),
+              ],
+            ),
+          ),
+        ),
+        DecomposedCourseDesignerCard.buildFooter(bottomMargin: 16),
+      ],
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/data/data_helpers/skill_rubrics_functions.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/cms_lesson_page.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+import 'skill_rubric_lesson_fanout_widget.dart';
+
+class NewSkillLessonRow extends StatefulWidget {
+  final SkillDimension dimension;
+  final SkillDegree degree;
+  final CourseDesignerState state;
+  final LibraryState library;
+
+  const NewSkillLessonRow({
+    super.key,
+    required this.dimension,
+    required this.degree,
+    required this.state,
+    required this.library,
+  });
+
+  @override
+  State<NewSkillLessonRow> createState() => _NewSkillLessonRowState();
+}
+
+class _NewSkillLessonRowState extends State<NewSkillLessonRow> {
+  final LayerLink _layerLink = LayerLink();
+
+  void _attach() {
+    final exclude = widget.degree.lessonRefs.map((e) => e.id).toSet();
+    SkillRubricLessonFanoutWidget.show(
+      context: context,
+      link: _layerLink,
+      libraryState: widget.library,
+      excludeLessonIds: exclude,
+      onSelected: (lesson) async {
+        final courseId = widget.state.course?.id;
+        if (courseId == null) return;
+        final updated = await SkillRubricsFunctions.addLesson(
+          courseId: courseId,
+          dimensionId: widget.dimension.id,
+          degreeId: widget.degree.id,
+          lessonId: lesson.id!,
+        );
+        if (updated != null) {
+          widget.state.skillRubric = updated;
+          widget.state.notifyListeners();
+        }
+      },
+    );
+  }
+
+  void _createLesson() {
+    Navigator.pushNamed(
+      context,
+      NavigationEnum.cmsLesson.route,
+      arguments: CmsLessonDetailArgument.forEditExistingLesson(null, null),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecomposedCourseDesignerCard.buildBody(
+      Padding(
+        padding: const EdgeInsets.fromLTRB(32, 8, 16, 8),
+        child: Row(
+          children: [
+            CompositedTransformTarget(
+              link: _layerLink,
+              child: InkWell(
+                onTap: _attach,
+                child: const Text('Attach lesson'),
+              ),
+            ),
+            const SizedBox(width: 16),
+            InkWell(
+              onTap: _createLesson,
+              child: const Text('Create lesson'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+
+class SkillDegreeRow extends StatelessWidget {
+  final SkillDimension dimension;
+  final SkillDegree degree;
+  final CourseDesignerState state;
+
+  const SkillDegreeRow({
+    super.key,
+    required this.dimension,
+    required this.degree,
+    required this.state,
+  });
+
+  Future<void> _edit(BuildContext context) async {
+    await showDialog(
+      context: context,
+      builder: (_) => ValueInputDialog(
+        'Edit degree',
+        degree.name,
+        'Name',
+        'Save',
+        (value) =>
+            (value == null || value.trim().isEmpty) ? 'Name cannot be empty' : null,
+        (newName) => state.updateSkillDegree(
+          dimensionId: dimension.id,
+          degreeId: degree.id,
+          name: newName.trim(),
+        ),
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context) {
+    DialogUtils.showConfirmationDialog(
+      context,
+      'Delete degree?',
+      'Are you sure you want to delete this degree?',
+      () => state.deleteSkillDegree(
+          dimensionId: dimension.id, degreeId: degree.id),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecomposedCourseDesignerCard.buildBody(
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: InkWell(
+                onTap: () => _edit(context),
+                child: Text('${degree.degree}. ${degree.name}'),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline, size: 18),
+              onPressed: () => _confirmDelete(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+
+class SkillDimensionRow extends StatelessWidget {
+  final SkillDimension dimension;
+  final CourseDesignerState state;
+
+  const SkillDimensionRow({
+    super.key,
+    required this.dimension,
+    required this.state,
+  });
+
+  Future<void> _edit(BuildContext context) async {
+    await showDialog(
+      context: context,
+      builder: (_) => ValueInputDialog(
+        'Edit dimension',
+        dimension.name,
+        'Name',
+        'Save',
+        (value) =>
+            (value == null || value.trim().isEmpty) ? 'Name cannot be empty' : null,
+        (newName) => state.updateSkillDimension(
+          dimensionId: dimension.id,
+          name: newName.trim(),
+        ),
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context) {
+    DialogUtils.showConfirmationDialog(
+      context,
+      'Delete dimension?',
+      'This will remove the dimension and all its degrees.',
+      () => state.deleteSkillDimension(dimension.id),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
+      dimension.name,
+      [
+        IconButton(
+          icon: const Icon(Icons.delete_outline, size: 20),
+          onPressed: () => _confirmDelete(context),
+        ),
+      ],
+    );
+
+    return InkWell(onTap: () => _edit(context), child: header);
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_lesson_fanout_widget.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_lesson_fanout_widget.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/data/lesson.dart';
+
+/// Shows an overlay menu to select a lesson from the library
+/// excluding any lesson IDs in [excludeLessonIds]. When a lesson
+/// is tapped, [onSelected] is invoked and the menu is dismissed.
+class SkillRubricLessonFanoutWidget {
+  static void show({
+    required BuildContext context,
+    required LayerLink link,
+    required LibraryState libraryState,
+    required Set<String> excludeLessonIds,
+    required Future<void> Function(Lesson lesson) onSelected,
+  }) {
+    late OverlayEntry entry;
+
+    void handleSelection(Lesson lesson) {
+      entry.remove();
+      onSelected(lesson);
+    }
+
+    entry = OverlayEntry(builder: (_) {
+      final box = context.findRenderObject() as RenderBox;
+      final origin = box.localToGlobal(Offset.zero);
+      final size = box.size;
+      final widgets = <Widget>[];
+
+      for (final level in libraryState.levels ?? []) {
+        final lessons = libraryState
+            .getLessonsByLevel(level.id!)
+            .where((l) => !excludeLessonIds.contains(l.id))
+            .toList();
+        if (lessons.isEmpty) continue;
+
+        widgets.add(
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Text(
+              level.title,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+        );
+        for (final lesson in lessons) {
+          widgets.add(
+            InkWell(
+              onTap: () => handleSelection(lesson),
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                child: Text(lesson.title),
+              ),
+            ),
+          );
+        }
+      }
+
+      final unattached = libraryState
+          .getUnattachedLessons()
+          .where((l) => !excludeLessonIds.contains(l.id))
+          .toList();
+      if (unattached.isNotEmpty) {
+        widgets.add(
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: const Text(
+              'Other lessons',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+        );
+        for (final lesson in unattached) {
+          widgets.add(
+            InkWell(
+              onTap: () => handleSelection(lesson),
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                child: Text(lesson.title),
+              ),
+            ),
+          );
+        }
+      }
+
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () => entry.remove(),
+        child: Stack(children: [
+          Positioned(
+            left: origin.dx,
+            top: origin.dy + size.height + 4,
+            child: CompositedTransformFollower(
+              link: link,
+              offset: Offset(0, size.height + 4),
+              showWhenUnlinked: false,
+              child: Material(
+                elevation: 6,
+                borderRadius: BorderRadius.circular(8),
+                child: Container(
+                  constraints:
+                      const BoxConstraints(maxHeight: 300, minWidth: 180),
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: widgets,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ]),
+      );
+    });
+
+    Overlay.of(context).insert(entry);
+  }
+}

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_list_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_list_view_card.dart
@@ -1,14 +1,64 @@
 import 'package:flutter/material.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_card.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/lesson.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'new_skill_degree_row.dart';
+import 'new_skill_dimension_row.dart';
+import 'new_skill_lesson_row.dart';
+import 'skill_degree_row.dart';
+import 'skill_dimension_row.dart';
+import 'skill_lesson_row.dart';
 
 class SkillRubricListViewCard extends StatelessWidget {
   const SkillRubricListViewCard({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const CourseDesignerCard(
-      title: 'Skill Rubric List',
-      body: SizedBox.shrink(),
+    return Consumer2<CourseDesignerState, LibraryState>(
+      builder: (context, state, library, child) {
+        final children = <Widget>[];
+        final rubric = state.skillRubric;
+
+        if (rubric != null) {
+          for (final dim in rubric.dimensions) {
+            children.add(SkillDimensionRow(dimension: dim, state: state));
+            for (final degree in dim.degrees) {
+              children.add(
+                SkillDegreeRow(dimension: dim, degree: degree, state: state),
+              );
+              for (final ref in degree.lessonRefs) {
+                final lesson = library.findLesson(ref.id);
+                if (lesson != null) {
+                  children.add(
+                    SkillLessonRow(
+                      dimension: dim,
+                      degree: degree,
+                      lesson: lesson,
+                      state: state,
+                      library: library,
+                    ),
+                  );
+                }
+              }
+              children.add(NewSkillLessonRow(
+                dimension: dim,
+                degree: degree,
+                state: state,
+                library: library,
+              ));
+            }
+            children.add(NewSkillDegreeRow(dimension: dim, state: state));
+            children.add(
+              DecomposedCourseDesignerCard.buildFooter(bottomMargin: 16),
+            );
+          }
+        }
+        children.add(NewSkillDimensionRow(state: state));
+
+        return ListView(children: children);
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- split skill rubric list card into dedicated row widgets for dimensions, degrees, and lessons
- add SkillRubricLessonFanoutWidget to attach or replace lessons via a context menu

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af79365324832ebe6a832ffdc6324b