### PR TITLE
Adjust progress card text for compact next lesson cards

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_home/progress_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
@@ -24,6 +25,19 @@ class ProgressCard extends StatelessWidget {
       double progress =
           totalLessons == 0 ? 0 : completed / totalLessons.toDouble();
       Color beltColor = BeltColorFunctions.getBeltColor(progress);
+
+      // Determine if the next lesson card is small (no cover image or all lessons learned)
+      bool shortText = false;
+      List<String> completedIds = studentState.getGraduatedLessonIds();
+      List<Lesson> remaining = lessons
+          .where((l) => l.courseId.id == course.id)
+          .where((l) => !completedIds.contains(l.id))
+          .toList()
+        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+      if (remaining.isEmpty || remaining.first.coverFireStoragePath == null) {
+        shortText = true;
+      }
+
       const double strokeWidth = 6;
       return Card(
           child: Padding(
@@ -42,7 +56,10 @@ class ProgressCard extends StatelessWidget {
               ),
             ),
             Center(
-              child: Text('$completed of $totalLessons\nlessons\ncompleted',
+              child: Text(
+                  shortText
+                      ? '$completed / $totalLessons'
+                      : '$completed of $totalLessons\nlessons\ncompleted',
                   textAlign: TextAlign.center,
                   style: CustomTextStyles.getBody(context)),
             ),


### PR DESCRIPTION
## Summary
- Condense progress card text to `X / Y` when the next lesson card lacks a cover image or all lessons are completed

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8342bf38832ead431b9b65b428af