### PR TITLE
style: refine skill rubrics icons

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
@@ -59,9 +59,22 @@ class SkillDegreeRow extends StatelessWidget {
                 child: Text('${degree.degree}. ${degree.name}'),
               ),
             ),
-            IconButton(
-              icon: const Icon(Icons.delete_outline, size: 18),
-              onPressed: () => _confirmDelete(context),
+            InkWell(
+              borderRadius: BorderRadius.circular(4),
+              onTap: () => _edit(context),
+              child: const Padding(
+                padding: EdgeInsets.all(4.0),
+                child: Icon(Icons.edit, size: 18, color: Colors.grey),
+              ),
+            ),
+            const SizedBox(width: 6),
+            InkWell(
+              borderRadius: BorderRadius.circular(4),
+              onTap: () => _confirmDelete(context),
+              child: const Padding(
+                padding: EdgeInsets.all(4.0),
+                child: Icon(Icons.delete_outline, size: 18, color: Colors.grey),
+              ),
             ),
           ],
         ),

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
@@ -47,9 +47,21 @@ class SkillDimensionRow extends StatelessWidget {
     final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
       dimension.name,
       [
-        IconButton(
-          icon: const Icon(Icons.delete_outline, size: 20),
-          onPressed: () => _confirmDelete(context),
+        InkWell(
+          borderRadius: BorderRadius.circular(4),
+          onTap: () => _edit(context),
+          child: const Padding(
+            padding: EdgeInsets.all(4.0),
+            child: Icon(Icons.edit, size: 20, color: Colors.grey),
+          ),
+        ),
+        InkWell(
+          borderRadius: BorderRadius.circular(4),
+          onTap: () => _confirmDelete(context),
+          child: const Padding(
+            padding: EdgeInsets.all(4.0),
+            child: Icon(Icons.delete_outline, size: 20, color: Colors.grey),
+          ),
         ),
       ],
     );

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_lesson_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_lesson_row.dart
@@ -104,22 +104,30 @@ class _SkillLessonRowState extends State<SkillLessonRow> {
         padding: const EdgeInsets.fromLTRB(32, 8, 16, 8),
         child: Row(
           children: [
-            Expanded(
-              child: InkWell(
-                onTap: _openLesson,
-                child: Text(widget.lesson.title),
-              ),
+            InkWell(
+              onTap: _openLesson,
+              child: Text(widget.lesson.title),
             ),
+            const SizedBox(width: 8),
             CompositedTransformTarget(
               link: _layerLink,
-              child: IconButton(
-                icon: const Icon(Icons.edit, size: 18),
-                onPressed: _replace,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(4),
+                onTap: _replace,
+                child: const Padding(
+                  padding: EdgeInsets.all(4.0),
+                  child: Icon(Icons.edit, size: 18, color: Colors.grey),
+                ),
               ),
             ),
-            IconButton(
-              icon: const Icon(Icons.delete_outline, size: 18),
-              onPressed: _delete,
+            const SizedBox(width: 6),
+            InkWell(
+              borderRadius: BorderRadius.circular(4),
+              onTap: _delete,
+              child: const Padding(
+                padding: EdgeInsets.all(4.0),
+                child: Icon(Icons.close, size: 18, color: Colors.grey),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add explicit edit & gray delete icons for skill rubric dimensions
- show right-aligned edit/delete icons for degrees
- adjust lesson row icons: gray, close button, inline placement

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb91a13f8832e90cb2753244fcd4e