### PR TITLE
Align degree icons directly after name

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
@@ -53,12 +53,11 @@ class SkillDegreeRow extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
         child: Row(
           children: [
-            Expanded(
-              child: InkWell(
-                onTap: () => _edit(context),
-                child: Text('${degree.degree}. ${degree.name}'),
-              ),
+            InkWell(
+              onTap: () => _edit(context),
+              child: Text('${degree.degree}. ${degree.name}'),
             ),
+            const SizedBox(width: 8),
             InkWell(
               borderRadius: BorderRadius.circular(4),
               onTap: () => _edit(context),


### PR DESCRIPTION
## Summary
- Ensure edit/delete icons follow immediately after degree names on skill rubric page

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(not run: flutter missing)*
- `flutter test` *(not run: flutter missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afbb5293cc832eb98529dd27cea780