### PR TITLE
Support adding new skill lessons

### DIFF
--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -14,14 +14,21 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 import 'package:social_learning/ui_foundation/helper_widgets/upload_lesson_cover_widget.dart';
 
 import '../data/data_helpers/teachable_item_functions.dart';
+import '../data/data_helpers/skill_rubrics_functions.dart';
+import 'package:social_learning/state/course_designer_state.dart';
 
 class CmsLessonDetailArgument {
   final String? levelId;
   final String? lessonId;
   final String? attachToTeachableItemId;
+  final String? attachToSkillDegreeId;
 
-  CmsLessonDetailArgument._(
-      {this.levelId, this.lessonId, this.attachToTeachableItemId});
+  CmsLessonDetailArgument._({
+    this.levelId,
+    this.lessonId,
+    this.attachToTeachableItemId,
+    this.attachToSkillDegreeId,
+  });
 
   factory CmsLessonDetailArgument.forEditExistingLesson(
       String? lessonId, String? levelId) {
@@ -32,6 +39,14 @@ class CmsLessonDetailArgument {
       String attachToTeachableItemId) {
     return CmsLessonDetailArgument._(
         attachToTeachableItemId: attachToTeachableItemId);
+  }
+
+  factory CmsLessonDetailArgument.forNewLessonToAttachToSkillDegree({
+    required String degreeId,
+  }) {
+    return CmsLessonDetailArgument._(
+      attachToSkillDegreeId: degreeId,
+    );
   }
 }
 
@@ -56,6 +71,7 @@ class CmsLessonState extends State<CmsLessonPage> {
   Lesson? _lesson;
   bool _isAdd = true;
   String? _attachToTeachableItemId;
+  String? _attachToSkillDegreeId;
   String? _titleError;
   String? _synopsisError;
   String? _instructionsError;
@@ -102,6 +118,7 @@ class CmsLessonState extends State<CmsLessonPage> {
       }
 
       _attachToTeachableItemId = argument.attachToTeachableItemId;
+      _attachToSkillDegreeId = argument.attachToSkillDegreeId;
     }
   }
 
@@ -428,6 +445,17 @@ class CmsLessonState extends State<CmsLessonPage> {
       if (_attachToTeachableItemId != null && newLessonId != null) {
         TeachableItemFunctions.addLessonToTeachableItem(
             itemId: _attachToTeachableItemId!, lessonId: newLessonId);
+      } else if (_attachToSkillDegreeId != null && newLessonId != null) {
+          final designerState =
+              Provider.of<CourseDesignerState>(context, listen: false);
+          final courseId = designerState.course?.id;
+          if (courseId != null) {
+            await SkillRubricsFunctions.addLessonByDegreeId(
+              courseId: courseId,
+              degreeId: _attachToSkillDegreeId!,
+              lessonId: newLessonId,
+            );
+          }
       }
     } else {
       var lesson = _lesson;
@@ -449,11 +477,14 @@ class CmsLessonState extends State<CmsLessonPage> {
     }
 
     if (mounted) {
-      if (_attachToTeachableItemId == null) {
-        NavigationEnum.cmsSyllabus.navigateCleanDelayed(context);
-      } else {
+      if (_attachToTeachableItemId != null) {
         NavigationEnum.courseDesignerLearningObjectives
             .navigateCleanDelayed(context);
+      } else if (_attachToSkillDegreeId != null) {
+        NavigationEnum.courseDesignerSkillRubric
+            .navigateCleanDelayed(context);
+      } else {
+        NavigationEnum.cmsSyllabus.navigateCleanDelayed(context);
       }
     }
   }

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
@@ -57,7 +57,9 @@ class _NewSkillLessonRowState extends State<NewSkillLessonRow> {
     Navigator.pushNamed(
       context,
       NavigationEnum.cmsLesson.route,
-      arguments: CmsLessonDetailArgument.forEditExistingLesson(null, null),
+      arguments: CmsLessonDetailArgument.forNewLessonToAttachToSkillDegree(
+        degreeId: widget.degree.id,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- allow creating a lesson directly from a skill degree
- attach new lessons to skill rubrics and return to skill rubric screen
- encapsulate skill-rubric lesson attachment with `addLessonByDegreeId`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af86066970832eabcbe7ac2be414de