### PR TITLE
Allow editing skill descriptions

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/data/skill_rubric.dart';
 import 'package:social_learning/state/course_designer_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_description_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
 
 class SkillDegreeRow extends StatelessWidget {
   final SkillDimension dimension;
@@ -17,20 +17,19 @@ class SkillDegreeRow extends StatelessWidget {
     required this.state,
   });
 
-  Future<void> _edit(BuildContext context) async {
+  Future<void> _openDialog(BuildContext context, bool editMode) async {
     await showDialog(
       context: context,
-      builder: (_) => ValueInputDialog(
-        'Edit degree',
-        degree.name,
-        'Name',
-        'Save',
-        (value) =>
-            (value == null || value.trim().isEmpty) ? 'Name cannot be empty' : null,
-        (newName) => state.updateSkillDegree(
+      builder: (_) => SkillDescriptionDialog(
+        itemType: 'Degree',
+        initialName: degree.name,
+        initialDescription: degree.description,
+        startInEditMode: editMode,
+        onSave: (name, description) => state.updateSkillDegree(
           dimensionId: dimension.id,
           degreeId: degree.id,
-          name: newName.trim(),
+          name: name,
+          description: description,
         ),
       ),
     );
@@ -55,13 +54,24 @@ class SkillDegreeRow extends StatelessWidget {
           children: [
             Expanded(
               child: InkWell(
-                onTap: () => _edit(context),
+                onTap: () => _openDialog(context, true),
                 child: Text('${degree.degree}. ${degree.name}'),
               ),
             ),
+            if (degree.description?.trim().isNotEmpty ?? false) ...[
+              InkWell(
+                borderRadius: BorderRadius.circular(4),
+                onTap: () => _openDialog(context, false),
+                child: const Padding(
+                  padding: EdgeInsets.all(4.0),
+                  child: Icon(Icons.notes, size: 18, color: Colors.grey),
+                ),
+              ),
+              const SizedBox(width: 6),
+            ],
             InkWell(
               borderRadius: BorderRadius.circular(4),
-              onTap: () => _edit(context),
+              onTap: () => _openDialog(context, true),
               child: const Padding(
                 padding: EdgeInsets.all(4.0),
                 child: Icon(Icons.edit, size: 18, color: Colors.grey),

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_description_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_description_dialog.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+
+/// Dialog for viewing and editing a name with an optional description.
+///
+/// Used by the skill rubric to edit [SkillDimension]s and [SkillDegree]s.
+class SkillDescriptionDialog extends StatefulWidget {
+  final String itemType;
+  final String initialName;
+  final String? initialDescription;
+  final bool startInEditMode;
+  final Future<void> Function(String name, String? description) onSave;
+
+  const SkillDescriptionDialog({
+    super.key,
+    required this.itemType,
+    required this.initialName,
+    this.initialDescription,
+    required this.onSave,
+    this.startInEditMode = false,
+  });
+
+  @override
+  State<SkillDescriptionDialog> createState() => _SkillDescriptionDialogState();
+}
+
+class _SkillDescriptionDialogState extends State<SkillDescriptionDialog> {
+  late bool isEditing;
+  late TextEditingController nameController;
+  late TextEditingController descriptionController;
+  String? nameError;
+
+  @override
+  void initState() {
+    super.initState();
+    isEditing = widget.startInEditMode;
+    nameController = TextEditingController(text: widget.initialName);
+    descriptionController =
+        TextEditingController(text: widget.initialDescription ?? '');
+  }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: isEditing
+          ? Text('Edit ${widget.itemType}')
+          : Text(widget.initialName),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 400, maxWidth: 500),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children:
+                isEditing ? _buildEditContent(context) : _buildPreviewContent(),
+          ),
+        ),
+      ),
+      actions: [
+        if (!isEditing)
+          TextButton(
+            onPressed: () => setState(() => isEditing = true),
+            child: const Text('Edit'),
+          ),
+        if (isEditing)
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  List<Widget> _buildEditContent(BuildContext context) {
+    return [
+      TextFormField(
+        controller: nameController,
+        decoration: CustomUiConstants.getFilledInputDecoration(
+          context,
+          labelText: '${widget.itemType} name',
+        ).copyWith(errorText: nameError),
+      ),
+      const SizedBox(height: 12),
+      TextFormField(
+        controller: descriptionController,
+        decoration: CustomUiConstants.getFilledInputDecoration(
+          context,
+          labelText: 'Description',
+        ),
+        maxLines: null,
+        minLines: 5,
+        keyboardType: TextInputType.multiline,
+      ),
+    ];
+  }
+
+  List<Widget> _buildPreviewContent() {
+    final description = descriptionController.text.trim();
+    return [
+      Align(
+        alignment: Alignment.centerLeft,
+        child: description.isEmpty
+            ? const Text('No description available.')
+            : Text(description),
+      ),
+    ];
+  }
+
+  Future<void> _save() async {
+    final name = nameController.text.trim();
+    final description = descriptionController.text.trim();
+
+    if (name.isEmpty) {
+      setState(() {
+        nameError = 'Name cannot be empty';
+      });
+      return;
+    }
+
+    setState(() {
+      nameError = null;
+    });
+
+    await widget.onSave(name, description.isEmpty ? null : description);
+    Navigator.of(context).pop();
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/data/skill_rubric.dart';
 import 'package:social_learning/state/course_designer_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_description_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
 
 class SkillDimensionRow extends StatelessWidget {
   final SkillDimension dimension;
@@ -15,19 +15,18 @@ class SkillDimensionRow extends StatelessWidget {
     required this.state,
   });
 
-  Future<void> _edit(BuildContext context) async {
+  Future<void> _openDialog(BuildContext context, bool editMode) async {
     await showDialog(
       context: context,
-      builder: (_) => ValueInputDialog(
-        'Edit dimension',
-        dimension.name,
-        'Name',
-        'Save',
-        (value) =>
-            (value == null || value.trim().isEmpty) ? 'Name cannot be empty' : null,
-        (newName) => state.updateSkillDimension(
+      builder: (_) => SkillDescriptionDialog(
+        itemType: 'Dimension',
+        initialName: dimension.name,
+        initialDescription: dimension.description,
+        startInEditMode: editMode,
+        onSave: (name, description) => state.updateSkillDimension(
           dimensionId: dimension.id,
-          name: newName.trim(),
+          name: name,
+          description: description,
         ),
       ),
     );
@@ -44,28 +43,41 @@ class SkillDimensionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
-      dimension.name,
-      [
+    final icons = <Widget>[];
+    if (dimension.description?.trim().isNotEmpty ?? false) {
+      icons.add(
         InkWell(
           borderRadius: BorderRadius.circular(4),
-          onTap: () => _edit(context),
+          onTap: () => _openDialog(context, false),
           child: const Padding(
             padding: EdgeInsets.all(4.0),
-            child: Icon(Icons.edit, size: 20, color: Colors.grey),
+            child: Icon(Icons.notes, size: 20, color: Colors.grey),
           ),
         ),
-        InkWell(
-          borderRadius: BorderRadius.circular(4),
-          onTap: () => _confirmDelete(context),
-          child: const Padding(
-            padding: EdgeInsets.all(4.0),
-            child: Icon(Icons.delete_outline, size: 20, color: Colors.grey),
-          ),
+      );
+    }
+    icons.addAll([
+      InkWell(
+        borderRadius: BorderRadius.circular(4),
+        onTap: () => _openDialog(context, true),
+        child: const Padding(
+          padding: EdgeInsets.all(4.0),
+          child: Icon(Icons.edit, size: 20, color: Colors.grey),
         ),
-      ],
-    );
+      ),
+      InkWell(
+        borderRadius: BorderRadius.circular(4),
+        onTap: () => _confirmDelete(context),
+        child: const Padding(
+          padding: EdgeInsets.all(4.0),
+          child: Icon(Icons.delete_outline, size: 20, color: Colors.grey),
+        ),
+      ),
+    ]);
 
-    return InkWell(onTap: () => _edit(context), child: header);
+    final header =
+        DecomposedCourseDesignerCard.buildHeaderWithIcons(dimension.name, icons);
+
+    return InkWell(onTap: () => _openDialog(context, true), child: header);
   }
 }


### PR DESCRIPTION
## Summary
- Support name and description editing for skill dimensions and degrees
- Show a notes icon when a description is present
- Indicate missing names directly on the dialog instead of using a snackbar

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbaf06488832e8135fa3d969b2772