### PR TITLE
Use CourseDesignerState for skill rubric lesson attach

### DIFF
--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -351,6 +351,21 @@ class CourseDesignerState extends ChangeNotifier {
     }
   }
 
+  Future<void> addLessonToSkillDegree(
+      {required String degreeId, required String lessonId}) async {
+    await _ensureInitialized();
+    if (_activeCourse == null) return;
+    final updated = await SkillRubricsFunctions.addLessonByDegreeId(
+      courseId: _activeCourse!.id!,
+      degreeId: degreeId,
+      lessonId: lessonId,
+    );
+    if (updated != null) {
+      skillRubric = updated;
+      notifyListeners();
+    }
+  }
+
   // ----- Inventory / Item management -----
   Future<void> addNewItem(TeachableItemCategory category, String name) async {
     await _ensureInitialized();

--- a/lib/ui_foundation/cms_lesson_page.dart
+++ b/lib/ui_foundation/cms_lesson_page.dart
@@ -14,7 +14,6 @@ import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart'
 import 'package:social_learning/ui_foundation/helper_widgets/upload_lesson_cover_widget.dart';
 
 import '../data/data_helpers/teachable_item_functions.dart';
-import '../data/data_helpers/skill_rubrics_functions.dart';
 import 'package:social_learning/state/course_designer_state.dart';
 
 class CmsLessonDetailArgument {
@@ -446,16 +445,12 @@ class CmsLessonState extends State<CmsLessonPage> {
         TeachableItemFunctions.addLessonToTeachableItem(
             itemId: _attachToTeachableItemId!, lessonId: newLessonId);
       } else if (_attachToSkillDegreeId != null && newLessonId != null) {
-          final designerState =
-              Provider.of<CourseDesignerState>(context, listen: false);
-          final courseId = designerState.course?.id;
-          if (courseId != null) {
-            await SkillRubricsFunctions.addLessonByDegreeId(
-              courseId: courseId,
-              degreeId: _attachToSkillDegreeId!,
-              lessonId: newLessonId,
-            );
-          }
+        final designerState =
+            Provider.of<CourseDesignerState>(context, listen: false);
+        await designerState.addLessonToSkillDegree(
+          degreeId: _attachToSkillDegreeId!,
+          lessonId: newLessonId,
+        );
       }
     } else {
       var lesson = _lesson;


### PR DESCRIPTION
## Summary
- add CourseDesignerState.addLessonToSkillDegree to update skill rubrics
- route lesson creation page through state instead of SkillRubricsFunctions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68afbf84d7dc832eba46c158cd595983