### PR TITLE
Align skill dimension icons with titles

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
@@ -20,7 +20,45 @@ class DecomposedCourseDesignerCard {
     );
   }
 
-  static Widget buildHeaderWithIcons(String title, List<Widget> icons) {
+  static Widget buildHeaderWithIcons(
+    String title,
+    List<Widget> icons, {
+    bool iconsRight = true,
+  }) {
+    final children = <Widget>[];
+
+    if (iconsRight) {
+      children.add(
+        Expanded(
+          child: Text(
+            title,
+            style: CourseDesignerTheme.cardHeaderTextStyle,
+          ),
+        ),
+      );
+
+      children.addAll(
+        icons.map(
+          (icon) => Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: icon,
+          ),
+        ),
+      );
+    } else {
+      children.add(
+        Text(
+          title,
+          style: CourseDesignerTheme.cardHeaderTextStyle,
+        ),
+      );
+
+      for (var icon in icons) {
+        children.add(const SizedBox(width: 6));
+        children.add(icon);
+      }
+    }
+
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
@@ -32,18 +70,7 @@ class DecomposedCourseDesignerCard {
       padding: CourseDesignerTheme.cardHeaderPadding,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            child: Text(
-              title,
-              style: CourseDesignerTheme.cardHeaderTextStyle,
-              ),
-          ),
-          ...icons.map((icon) => Padding(
-                padding: const EdgeInsets.only(left: 8.0),
-                child: icon,
-              )),
-        ],
+        children: children,
       ),
     );
   }

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
@@ -75,8 +75,11 @@ class SkillDimensionRow extends StatelessWidget {
       ),
     ]);
 
-    final header =
-        DecomposedCourseDesignerCard.buildHeaderWithIcons(dimension.name, icons);
+    final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
+      dimension.name,
+      icons,
+      iconsRight: false,
+    );
 
     return InkWell(onTap: () => _openDialog(context, true), child: header);
   }


### PR DESCRIPTION
## Summary
- Allow `DecomposedCourseDesignerCard.buildHeaderWithIcons` to optionally place icons immediately after the title
- Show skill dimension action icons directly beside the dimension name on the rubric page

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbfe60c60832e82925e597e54971c