### PR TITLE
feat: add skill rubric generation service

### DIFF
--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/GenerateSkillRubricRequest.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/GenerateSkillRubricRequest.java
@@ -1,0 +1,19 @@
+package com.playposse.learninglab.server.firebase_server;
+
+/**
+ * Request payload for generating a skill rubric for a course.
+ * Contains information from the Course and CourseProfile.
+ */
+public class GenerateSkillRubricRequest {
+    public String uid; // set by controller after verifying token
+    public String title;
+    public String description;
+    public String topicAndFocus;
+    public String scheduleAndDuration;
+    public String targetAudience;
+    public String groupSizeAndFormat;
+    public String location;
+    public String howStudentsJoin;
+    public String toneAndApproach;
+    public String anythingUnusual;
+}

--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricController.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricController.java
@@ -1,0 +1,46 @@
+package com.playposse.learninglab.server.firebase_server;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseToken;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * REST endpoint for generating skill rubrics using OpenAI.
+ */
+@RestController
+@RequestMapping("/api")
+public class SkillRubricController {
+
+    private final SkillRubricService skillRubricService;
+
+    public SkillRubricController(SkillRubricService skillRubricService) {
+        this.skillRubricService = skillRubricService;
+    }
+
+    @PostMapping("/generate-skill-rubric")
+    public ResponseEntity<?> generateSkillRubric(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+            @RequestBody GenerateSkillRubricRequest request) {
+        try {
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(Map.of("error", "Missing or invalid Authorization header"));
+            }
+
+            String idToken = authorization.substring(7);
+            FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
+            request.uid = decodedToken.getUid();
+
+            SkillRubricResponse result = skillRubricService.generateRubric(request);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+}

--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricResponse.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricResponse.java
@@ -1,0 +1,54 @@
+package com.playposse.learninglab.server.firebase_server;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response object containing the full hierarchical skill rubric
+ * with dimensions, degrees, and lessons.
+ */
+public class SkillRubricResponse {
+    public final List<SkillDimension> dimensions;
+
+    public SkillRubricResponse(List<SkillDimension> dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    /**
+     * Builds a hierarchical SkillRubricResponse from the DSL output lists.
+     */
+    public static SkillRubricResponse fromDsl(List<String> dims, List<JsonNode> detailNodes) {
+        ObjectMapper mapper = new ObjectMapper();
+        List<SkillDimension> dimensionList = new ArrayList<>();
+
+        for (int i = 0; i < dims.size(); i++) {
+            String name = dims.get(i);
+            JsonNode node = i < detailNodes.size() ? detailNodes.get(i) : null;
+            String description = node != null ? node.path("description").asText() : "";
+
+            List<SkillDegree> degreeList = new ArrayList<>();
+            if (node != null) {
+                for (JsonNode degreeNode : node.path("degrees")) {
+                    String degreeName = degreeNode.path("degree").asText();
+                    String criteria = degreeNode.path("criteria").asText();
+                    List<String> lessons = mapper.convertValue(
+                            degreeNode.path("exercises"),
+                            new TypeReference<List<String>>() {}
+                    );
+                    degreeList.add(new SkillDegree(degreeName, criteria, lessons));
+                }
+            }
+
+            dimensionList.add(new SkillDimension(name, description, degreeList));
+        }
+
+        return new SkillRubricResponse(dimensionList);
+    }
+
+    public record SkillDimension(String name, String description, List<SkillDegree> degrees) {}
+    public record SkillDegree(String name, String criteria, List<String> lessons) {}
+}

--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricService.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricService.java
@@ -1,0 +1,117 @@
+package com.playposse.learninglab.server.firebase_server;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.playposse.learninglab.server.firebase_server.openaidsl.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service that calls OpenAI to generate skill dimensions and degrees
+ * for a course's skill rubric. It does not read or write Firestore
+ * and simply returns the generated structure.
+ */
+@Service
+public class SkillRubricService {
+
+    private final OpenAiClient openAiClient;
+    private final ChatConfig defaults;
+
+    @Autowired
+    public SkillRubricService(SecretFetcher secretFetcher) {
+        String apiKey;
+        try {
+            apiKey = secretFetcher.getOpenAiApiKey();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to fetch OpenAI API key", e);
+        }
+
+        this.openAiClient = new OpenAiClientImpl(apiKey);
+        this.defaults = new DefaultsBuilder()
+                .temperature(0.7)
+                .maxTokens(3000)
+                .build();
+    }
+
+    /**
+     * Generates skill dimensions, descriptions and degrees by
+     * chaining OpenAI calls. The description of a dimension is fed
+     * into the follow-up request for the degrees so that each branch
+     * can proceed independently.
+     */
+    public SkillRubricResponse generateRubric(GenerateSkillRubricRequest request) throws Exception {
+        String info = buildInfo(request);
+
+        // labels
+        Label<List<String>> DIMENSIONS = Label.of("dimensions", new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        Label<Object> DETAIL = Label.of("detail", Object.class); // reused for description and degree JSON
+        Label<List<JsonNode>> DETAILS = Label.of("details", new com.fasterxml.jackson.core.type.TypeReference<>() {});
+
+        String systemMessage =
+                "You are an expert educator designing skill rubrics. A skill dimension is a major competency " +
+                        "area for the course. Each dimension has five skill degrees from novice to expert, each with " +
+                        "criteria and exercises.";
+
+        ChainResult result = ChainBuilder
+                .start(defaults)
+
+                // Step 1: brainstorm dimensions
+                .step("dimensions")
+                .system(systemMessage)
+                .user(info + "\n\nList the key skill dimensions for this course. Return one per line.")
+                .parse(Parsers.stringList())
+                .label(DIMENSIONS)
+                .endStep()
+
+                // Step 2 & 3: for each dimension, first get a description, then degrees
+                .forEach(DIMENSIONS)
+                .alias("dimension")
+                .addStep(
+                        StepBuilder.start("dimensionDescription", defaults)
+                                .system(systemMessage)
+                                .user(info + "\n\nDimension: ${dimension}\nDescribe this skill dimension in 2-3 sentences.")
+                                .parse(Parsers.string())
+                                .label(DETAIL) // temporarily holds description
+                                .build()
+                )
+                .addStep(
+                        StepBuilder.start("skillDegrees", defaults)
+                                .system(systemMessage)
+                                .user(info + "\n\nDimension: ${dimension}\nDescription: ${detail}\nProvide 5 skill degrees from novice to expert. " +
+                                        "For each degree, specify the criteria a student must demonstrate and three exercise lessons to develop " +
+                                        "from the current degree to the next degree. Return JSON object with fields 'description' (copy of the description) " +
+                                        "and 'degrees' array with objects having 'degree', 'criteria', and 'exercises'.")
+                                .parse(Parsers.json())
+                                .label(DETAIL) // overwrites description with combined JSON
+                                .build()
+                )
+                .joinInto(DETAILS)
+                .endForEach()
+
+                .build()
+                .run(openAiClient);
+
+        List<String> dims = result.get(DIMENSIONS);
+        List<JsonNode> detailNodes = result.get(DETAILS);
+
+        return SkillRubricResponse.fromDsl(dims, detailNodes);
+    }
+
+    private String buildInfo(GenerateSkillRubricRequest d) {
+        return "Course title: " + safe(d.title) + "\n" +
+                "Course description: " + safe(d.description) + "\n" +
+                "Topic and focus: " + safe(d.topicAndFocus) + "\n" +
+                "Schedule and duration: " + safe(d.scheduleAndDuration) + "\n" +
+                "Target audience: " + safe(d.targetAudience) + "\n" +
+                "Group size and format: " + safe(d.groupSizeAndFormat) + "\n" +
+                "Location: " + safe(d.location) + "\n" +
+                "How students join: " + safe(d.howStudentsJoin) + "\n" +
+                "Tone and approach: " + safe(d.toneAndApproach) + "\n" +
+                "Anything unusual: " + safe(d.anythingUnusual);
+    }
+
+    private static String safe(String s) {
+        return s == null ? "" : s;
+    }
+}


### PR DESCRIPTION
## Summary
- run dimension description and degree prompts in a single fork, passing descriptions into degree generation
- add `SkillRubric` container converting three flat collections into a dimension→degree→lesson hierarchy
- expose hierarchical results via `SkillRubricController`

## Testing
- `bash gradlew test` *(fails: FirebaseServerApplicationTests > contextLoads() FAILED: UnsatisfiedDependencyException)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc80dc668832eb6cf8dd2afda45d2