### PR TITLE
Fix null safety in skill rubric drag helper

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_drag_helper.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_drag_helper.dart
@@ -119,13 +119,13 @@ class SkillRubricDragHelper {
   ) async {
     final targetDimId = target.dimension.id;
     final targetDegreeId = target.degree.id;
-    final toDeg = state.skillRubric?.dimensions
+    final toDeg = state.skillRubric!.dimensions
         .firstWhere((d) => d.id == targetDimId)
         .degrees
         .firstWhere((d) => d.id == targetDegreeId);
     final toIndex =
         toDeg.lessonRefs.indexWhere((r) => r.id == target.lesson.id!);
-    final fromDeg = state.skillRubric?.dimensions
+    final fromDeg = state.skillRubric!.dimensions
         .firstWhere((d) => d.id == dragged.dimension.id)
         .degrees
         .firstWhere((d) => d.id == dragged.degree.id);
@@ -146,12 +146,12 @@ class SkillRubricDragHelper {
   ) async {
     final targetDimId = target.dimension.id;
     final targetDegreeId = target.degree.id;
-    final toDeg = state.skillRubric?.dimensions
+    final toDeg = state.skillRubric!.dimensions
         .firstWhere((d) => d.id == targetDimId)
         .degrees
         .firstWhere((d) => d.id == targetDegreeId);
     final toIndex = toDeg.lessonRefs.length;
-    final fromDeg = state.skillRubric?.dimensions
+    final fromDeg = state.skillRubric!.dimensions
         .firstWhere((d) => d.id == dragged.dimension.id)
         .degrees
         .firstWhere((d) => d.id == dragged.degree.id);
@@ -171,7 +171,7 @@ class SkillRubricDragHelper {
     SkillDegreeRow target,
   ) async {
     final targetDegreeId = target.degree.id;
-    final fromDeg = state.skillRubric?.dimensions
+    final fromDeg = state.skillRubric!.dimensions
         .firstWhere((d) => d.id == dragged.dimension.id)
         .degrees
         .firstWhere((d) => d.id == dragged.degree.id);


### PR DESCRIPTION
## Summary
- use non-null assertions when retrieving lesson degrees for drag operations

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(not run: flutter missing)*
- `flutter test` *(not run: flutter missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afd56e38d4832e83ce4885be54b95f