### PR TITLE
Align drag handle to right on rubric dimension rows

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
@@ -24,6 +24,7 @@ class DecomposedCourseDesignerCard {
     String title,
     List<Widget> icons, {
     bool iconsRight = true,
+    List<Widget> trailingIcons = const [],
   }) {
     final children = <Widget>[];
 
@@ -57,6 +58,19 @@ class DecomposedCourseDesignerCard {
         children.add(const SizedBox(width: 6));
         children.add(icon);
       }
+
+      children.add(const Spacer());
+    }
+
+    if (trailingIcons.isNotEmpty) {
+      children.addAll(
+        trailingIcons.map(
+          (icon) => Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: icon,
+          ),
+        ),
+      );
     }
 
     return Container(

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_dimension_row.dart
@@ -78,17 +78,16 @@ class SkillDimensionRow extends StatelessWidget implements SkillRubricRow {
       ),
     ]);
 
-    icons.add(
-      ReorderableDragStartListener(
-        index: dragHandleIndex,
-        child: const Icon(Icons.drag_handle, color: Colors.grey, size: 20),
-      ),
-    );
-
     final header = DecomposedCourseDesignerCard.buildHeaderWithIcons(
       dimension.name,
       icons,
       iconsRight: false,
+      trailingIcons: [
+        ReorderableDragStartListener(
+          index: dragHandleIndex,
+          child: const Icon(Icons.drag_handle, color: Colors.grey, size: 20),
+        ),
+      ],
     );
 
     return InkWell(onTap: () => _openDialog(context, true), child: header);


### PR DESCRIPTION
## Summary
- Keep edit, description and delete icons next to dimension titles
- Right-align drag handle using new `trailingIcons` support in card header builder

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68afd8245f28832e9b2b87dcbddc503d