### PR TITLE
Refine magic wand icon in skill rubric card

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_info_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_info_card.dart
@@ -34,10 +34,16 @@ class SkillRubricInfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return CourseDesignerCard(
       title: 'Step 5: Skill Rubric',
-      titleIcon: IconButton(
-        icon: const Icon(Icons.auto_fix_high),
-        tooltip: 'Generate with AI',
-        onPressed: () => _onAIPressed(context),
+      titleIcon: Tooltip(
+        message: 'Generate with AI',
+        child: InkWell(
+          borderRadius: BorderRadius.circular(4),
+          onTap: () => _onAIPressed(context),
+          child: const Padding(
+            padding: EdgeInsets.all(4.0),
+            child: Icon(Icons.auto_fix_high, size: 16, color: Colors.grey),
+          ),
+        ),
       ),
       body: const Text(
         'Acquiring knowledge and developing skills are key to mastering '


### PR DESCRIPTION
## Summary
- Reduce skill rubric info card header height and icon size
- Replace IconButton with compact InkWell + Tooltip for AI generation

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc9fb0f8832ebb104f2112268243