### PR TITLE
Use PopScope in blocking spinner dialog

### DIFF
--- a/lib/ui_foundation/helper_widgets/general/blocking_spinner_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/general/blocking_spinner_dialog.dart
@@ -21,8 +21,12 @@ class _BlockingSpinner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const WillPopScope(
-      onWillPop: () async => false,
+    // `PopScope` is used instead of the deprecated `WillPopScope` so that the
+    // user cannot dismiss the dialog via the system back button. Setting
+    // `canPop` to false ensures the route cannot be popped until the caller
+    // explicitly dismisses the dialog.
+    return const PopScope(
+      canPop: false,
       child: Dialog(
         backgroundColor: Colors.transparent,
         elevation: 0,


### PR DESCRIPTION
## Summary
- use `PopScope` instead of deprecated `WillPopScope` to prevent dismissing the blocking spinner dialog

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68afef6f5ea8832e90d60042ecabe680