### PR TITLE
Align skill rubric rows and drag handles

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_degree_row.dart
@@ -37,7 +37,7 @@ class _NewSkillDegreeRowState extends State<NewSkillDegreeRow> {
   Widget build(BuildContext context) {
     return DecomposedCourseDesignerCard.buildBody(
       Padding(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        padding: const EdgeInsets.fromLTRB(0, 8, 0, 8),
         child: Row(
           children: [
             Expanded(

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_dimension_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_dimension_row.dart
@@ -35,7 +35,7 @@ class _NewSkillDimensionRowState extends State<NewSkillDimensionRow> {
         DecomposedCourseDesignerCard.buildHeader('Add new dimension'),
         DecomposedCourseDesignerCard.buildBody(
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            padding: const EdgeInsets.fromLTRB(0, 8, 0, 8),
             child: Row(
               children: [
                 Expanded(

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/new_skill_lesson_row.dart
@@ -71,7 +71,7 @@ class _NewSkillLessonRowState extends State<NewSkillLessonRow> {
   Widget build(BuildContext context) {
     return DecomposedCourseDesignerCard.buildBody(
       Padding(
-        padding: const EdgeInsets.fromLTRB(32, 8, 16, 8),
+        padding: const EdgeInsets.fromLTRB(16, 8, 0, 8),
         child: Row(
           children: [
             CompositedTransformTarget(

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_degree_row.dart
@@ -52,13 +52,13 @@ class SkillDegreeRow extends StatelessWidget implements SkillRubricRow {
   Widget build(BuildContext context) {
     return DecomposedCourseDesignerCard.buildBody(
       Padding(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        padding: const EdgeInsets.fromLTRB(0, 8, 0, 8),
         child: Row(
           children: [
             InkWell(
-                onTap: () => _openDialog(context, true),
-                child: Text('${degree.degree}. ${degree.name}'),
-              ),
+              onTap: () => _openDialog(context, true),
+              child: Text('${degree.degree}. ${degree.name}'),
+            ),
 
             if (degree.description?.trim().isNotEmpty ?? false) ...[
               InkWell(

--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_lesson_row.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_lesson_row.dart
@@ -104,7 +104,7 @@ class _SkillLessonRowState extends State<SkillLessonRow> {
   Widget build(BuildContext context) {
     return DecomposedCourseDesignerCard.buildBody(
       Padding(
-        padding: const EdgeInsets.fromLTRB(32, 8, 16, 8),
+        padding: const EdgeInsets.fromLTRB(16, 8, 0, 8),
         child: Row(
           children: [
             InkWell(


### PR DESCRIPTION
## Summary
- Restore fixed padding for `DecomposedCourseDesignerCard.buildBody`
- Remove extra left/right padding from skill rubric rows to align text with headers and drag handles

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afdc14fe74832e8c9784df65748d82