### PR TITLE
Allow in-place updates for skill rubrics

### DIFF
--- a/lib/data/skill_rubric.dart
+++ b/lib/data/skill_rubric.dart
@@ -3,9 +3,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class SkillRubric {
   final String? id;
   final DocumentReference courseId;
-  final List<SkillDimension> dimensions;
+  List<SkillDimension> dimensions;
   final Timestamp createdAt;
-  final Timestamp modifiedAt;
+  Timestamp modifiedAt;
 
   SkillRubric({
     this.id,
@@ -39,9 +39,9 @@ class SkillRubric {
 
 class SkillDimension {
   final String id;
-  final String name;
-  final String? description;
-  final List<SkillDegree> degrees;
+  String name;
+  String? description;
+  List<SkillDegree> degrees;
 
   SkillDimension({
     required this.id,
@@ -69,10 +69,10 @@ class SkillDimension {
 
 class SkillDegree {
   final String id;
-  final int degree;
-  final String name;
-  final String? description;
-  final List<DocumentReference> lessonRefs;
+  int degree;
+  String name;
+  String? description;
+  List<DocumentReference> lessonRefs;
 
   SkillDegree({
     required this.id,


### PR DESCRIPTION
## Summary
- Make SkillRubric, SkillDimension, and SkillDegree mutable where edits are needed
- Update SkillRubricsFunctions to mutate existing objects instead of rebuilding them

## Testing
- ❌ `flutter pub get` *(flutter: command not found)*
- ❌ `flutter analyze` *(flutter: command not found)*
- ❌ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c5ac2340832e9dfe29643c99e833