### PR TITLE
Break skill degree generation into separate steps

### DIFF
--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricService.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/SkillRubricService.java
@@ -1,11 +1,17 @@
 package com.playposse.learninglab.server.firebase_server;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.playposse.learninglab.server.firebase_server.openaidsl.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Service that calls OpenAI to generate skill dimensions and degrees
@@ -44,9 +50,11 @@ public class SkillRubricService {
         String info = buildInfo(request);
 
         // labels
+        Label<List<String>> DEGREE_LABELS = Label.of("degreeLabels", new com.fasterxml.jackson.core.type.TypeReference<>() {});
         Label<List<String>> DIMENSIONS = Label.of("dimensions", new com.fasterxml.jackson.core.type.TypeReference<>() {});
-        Label<Object> DETAIL = Label.of("detail", Object.class); // reused for description and degree JSON
-        Label<List<JsonNode>> DETAILS = Label.of("details", new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        Label<String> DETAIL = Label.of("detail", String.class); // reused for interim strings
+        Label<List<String>> DEGREE_DESCRIPTIONS = Label.of("degreeDescriptions", new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        Label<List<String>> DEGREE_EXERCISES = Label.of("degreeExercises", new com.fasterxml.jackson.core.type.TypeReference<>() {});
 
         String systemMessage =
                 "You are an expert educator designing skill rubrics. A skill dimension is a major competency " +
@@ -56,44 +64,100 @@ public class SkillRubricService {
         ChainResult result = ChainBuilder
                 .start(defaults)
 
-                // Step 1: brainstorm dimensions
+                // Step 1: get global degree labels
+                .step("degreeLabels")
+                .system(systemMessage)
+                .user(info + "\n\nList the five skill degree labels from novice to expert. Return one per line.")
+                .parse(Parsers.stringList())
+                .label(DEGREE_LABELS)
+                .maxTokens(50)
+                .endStep()
+
+                // Step 2: brainstorm dimensions
                 .step("dimensions")
                 .system(systemMessage)
-                .user(info + "\n\nList the key skill dimensions for this course. Return one per line.")
+                .user(info + "\n\nList 5-7 key skill dimensions for this course. Return one per line.")
                 .parse(Parsers.stringList())
                 .label(DIMENSIONS)
                 .endStep()
 
-                // Step 2 & 3: for each dimension, first get a description, then degrees
+                // Step 3: for each dimension get degree criteria
                 .forEach(DIMENSIONS)
                 .alias("dimension")
                 .addStep(
-                        StepBuilder.start("dimensionDescription", defaults)
+                        StepBuilder.start("degreeDescriptions", defaults)
                                 .system(systemMessage)
-                                .user(info + "\n\nDimension: ${dimension}\nDescribe this skill dimension in 2-3 sentences.")
+                                .user(info + "\n\nDimension: ${dimension}\nDegree labels: ${degreeLabels}\nFor each degree, describe what a student must demonstrate at that degree for this dimension. Return one paragraph per degree, separated by a blank line, and follow the order of the degree labels.")
                                 .parse(Parsers.string())
-                                .label(DETAIL) // temporarily holds description
+                                .label(DETAIL)
+                                .maxTokens(800)
                                 .build()
                 )
+                .joinInto(DEGREE_DESCRIPTIONS)
+                .endForEach()
+
+                // Step 4: for each dimension get exercises
+                .forEach(DIMENSIONS)
+                .alias("dimension")
                 .addStep(
-                        StepBuilder.start("skillDegrees", defaults)
+                        StepBuilder.start("degreeExercises", defaults)
                                 .system(systemMessage)
-                                .user(info + "\n\nDimension: ${dimension}\nDescription: ${detail}\nProvide 5 skill degrees from novice to expert. " +
-                                        "For each degree, specify the criteria a student must demonstrate and three exercise lessons to develop " +
-                                        "from the current degree to the next degree. Return JSON object with fields 'description' (copy of the description) " +
-                                        "and 'degrees' array with objects having 'degree', 'criteria', and 'exercises'.")
-                                .parse(Parsers.json())
-                                .label(DETAIL) // overwrites description with combined JSON
+                                .user(info + "\n\nDimension: ${dimension}\nDegree labels: ${degreeLabels}\nFor each degree, list three exercises a student can do to progress to the next degree. Provide one exercise per line and separate each group of exercises by a blank line. Follow the order of the degree labels.")
+                                .parse(Parsers.string())
+                                .label(DETAIL)
+                                .maxTokens(800)
                                 .build()
                 )
-                .joinInto(DETAILS)
+                .joinInto(DEGREE_EXERCISES)
                 .endForEach()
 
                 .build()
                 .run(openAiClient);
 
         List<String> dims = result.get(DIMENSIONS);
-        List<JsonNode> detailNodes = result.get(DETAILS);
+        List<String> degreeLabels = result.get(DEGREE_LABELS);
+        List<String> degreeDescStrings = result.get(DEGREE_DESCRIPTIONS);
+        List<String> degreeExerciseStrings = result.get(DEGREE_EXERCISES);
+
+        ObjectMapper mapper = new ObjectMapper();
+        List<JsonNode> detailNodes = new ArrayList<>();
+        for (int i = 0; i < dims.size(); i++) {
+            String descBlock = i < degreeDescStrings.size() ? degreeDescStrings.get(i) : "";
+            List<String> criteriaList = Arrays.stream(descBlock.split("\n\n"))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+
+            String exBlock = i < degreeExerciseStrings.size() ? degreeExerciseStrings.get(i) : "";
+            List<List<String>> exerciseGroups = Arrays.stream(exBlock.split("\n\n"))
+                    .map(group -> Arrays.stream(group.split("\n"))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .collect(Collectors.toList()))
+                    .collect(Collectors.toList());
+
+            ArrayNode degreesArr = mapper.createArrayNode();
+            for (int j = 0; j < degreeLabels.size(); j++) {
+                String degreeName = degreeLabels.get(j);
+                String criteria = j < criteriaList.size() ? criteriaList.get(j) : "";
+                List<String> exercises = j < exerciseGroups.size() ? exerciseGroups.get(j) : List.of();
+
+                ObjectNode degreeNode = mapper.createObjectNode();
+                degreeNode.put("degree", degreeName);
+                degreeNode.put("criteria", criteria);
+                ArrayNode exArr = mapper.createArrayNode();
+                for (String ex : exercises) {
+                    exArr.add(ex);
+                }
+                degreeNode.set("exercises", exArr);
+                degreesArr.add(degreeNode);
+            }
+
+            ObjectNode dimNode = mapper.createObjectNode();
+            dimNode.put("description", "");
+            dimNode.set("degrees", degreesArr);
+            detailNodes.add(dimNode);
+        }
 
         return SkillRubricResponse.fromDsl(dims, detailNodes);
     }


### PR DESCRIPTION
## Summary
- Centralize degree label generation and reuse across all skill dimensions
- Retrieve criteria and exercises for each dimension using paragraph-based outputs
- Parse paragraph and line-separated responses into structured degree objects

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `cd java-server && ./gradlew test` *(fails: FirebaseServerApplicationTests > contextLoads())*

------
https://chatgpt.com/codex/tasks/task_e_68b0d2747168832eac254a7a231aab34