### PR TITLE
Add instructor skill assessment page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ import 'package:social_learning/ui_foundation/session_host_page.dart';
 import 'package:social_learning/ui_foundation/session_student_page.dart';
 import 'package:social_learning/ui_foundation/sign_in_page.dart';
 import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
+import 'package:social_learning/ui_foundation/create_skill_assessment_page.dart';
 
 import 'firebase_options.dart';
 import 'ui_foundation/profile_page.dart';
@@ -173,6 +174,7 @@ class SocialLearningApp extends StatelessWidget {
         '/code_of_conduct': (context) => const CodeOfConductPage(),
         '/instructor_dashboard': (context) => const InstructorDashboardPage(),
         '/instructor_clipboard': (context) => const InstructorClipboardPage(),
+        '/create_skill_assessment': (context) => const CreateSkillAssessmentPage(),
         '/course_generation': (context) => const CourseGenerationPage(),
         '/course_generation_review': (context) =>
             const CourseGenerationReviewPage(),

--- a/lib/ui_foundation/create_skill_assessment_page.dart
+++ b/lib/ui_foundation/create_skill_assessment_page.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/skill_assessment.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/data/user.dart' as model;
+import 'package:social_learning/data/data_helpers/skill_assessment_functions.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
+import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/skill_assessment/skill_assessment_header_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/skill_assessment/skill_dimension_card.dart';
+
+/// Arguments to navigate to [CreateSkillAssessmentPage].
+class CreateSkillAssessmentPageArgument {
+  final String studentId;
+  final String studentUid;
+
+  CreateSkillAssessmentPageArgument(this.studentId, this.studentUid);
+
+  static void navigateTo(BuildContext context, String studentId, String studentUid) {
+    Navigator.pushNamed(
+      context,
+      NavigationEnum.createSkillAssessment.route,
+      arguments: CreateSkillAssessmentPageArgument(studentId, studentUid),
+    );
+  }
+}
+
+class CreateSkillAssessmentPage extends StatefulWidget {
+  const CreateSkillAssessmentPage({super.key});
+
+  @override
+  State<CreateSkillAssessmentPage> createState() => _CreateSkillAssessmentPageState();
+}
+
+class _CreateSkillAssessmentPageState extends State<CreateSkillAssessmentPage> {
+  model.User? _student;
+  SkillAssessment? _latestAssessment;
+  final TextEditingController _notesController = TextEditingController();
+  final Map<String, int?> _selectedDegrees = {};
+  final Map<String, int> _previousDegrees = {};
+
+  String? get _studentId =>
+      (ModalRoute.of(context)?.settings.arguments as CreateSkillAssessmentPageArgument?)?.studentId;
+  String? get _studentUid =>
+      (ModalRoute.of(context)?.settings.arguments as CreateSkillAssessmentPageArgument?)?.studentUid;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    context.read<CourseDesignerState>().ensureInitialized();
+
+    final id = _studentId, uid = _studentUid;
+    if (_student == null && id != null && uid != null) {
+      Future.microtask(() async {
+        final user = await UserFunctions.getUserById(id);
+        if (!mounted) return;
+        setState(() => _student = user);
+        final courseId = context.read<LibraryState>().selectedCourse?.id;
+        if (courseId != null) {
+          final assessment = await SkillAssessmentFunctions.latestForUser(
+              courseId: courseId, studentUid: uid);
+          if (assessment != null && mounted) {
+            setState(() {
+              _latestAssessment = assessment;
+              for (final d in assessment.dimensions) {
+                _previousDegrees[d.id] = d.degree;
+              }
+            });
+          }
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const LearningLabAppBar(title: 'Skill Assessment'),
+      bottomNavigationBar: BottomBarV2.build(context),
+      floatingActionButton: Consumer2<CourseDesignerState, LibraryState>(
+        builder: (context, designerState, libraryState, _) {
+          final rubric = designerState.skillRubric;
+          final course = libraryState.selectedCourse;
+          if (rubric == null || _student == null || course == null) {
+            return const SizedBox.shrink();
+          }
+          return FloatingActionButton(
+            onPressed: _allSelected(rubric)
+                ? () => _saveAssessment(rubric, course.id!)
+                : null,
+            tooltip: 'Save Assessment',
+            child: const Icon(Icons.save),
+          );
+        },
+      ),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: CustomUiConstants.framePage(
+          enableCreatorGuard: true,
+          Consumer2<CourseDesignerState, LibraryState>(
+            builder: (context, designerState, libraryState, _) {
+              final rubric = designerState.skillRubric;
+              final course = libraryState.selectedCourse;
+              if (rubric == null || _student == null || course == null) {
+                return const Padding(
+                  padding: EdgeInsets.all(32),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+
+              final currentDimensions = rubric.dimensions
+                  .map((d) => SkillAssessmentDimension(
+                        id: d.id,
+                        name: d.name,
+                        degree: _selectedDegrees[d.id] ?? 0,
+                        maxDegrees: d.degrees.length,
+                      ))
+                  .toList();
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SkillAssessmentHeaderCard(
+                    student: _student!,
+                    latestAssessment: _latestAssessment,
+                    currentDimensions: currentDimensions,
+                    notesController: _notesController,
+                  ),
+                  const SizedBox(height: 8),
+                  ...rubric.dimensions.map((dim) {
+                    return SkillDimensionCard(
+                      dimension: dim,
+                      selectedDegree: _selectedDegrees[dim.id],
+                      previousDegree: _previousDegrees[dim.id],
+                      onDegreeSelected: (degree) {
+                        setState(() {
+                          _selectedDegrees[dim.id] = degree;
+                        });
+                      },
+                    );
+                  }).toList(),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool _allSelected(SkillRubric rubric) {
+    return rubric.dimensions.every((d) => _selectedDegrees[d.id] != null);
+  }
+
+  Future<void> _saveAssessment(SkillRubric rubric, String courseId) async {
+    final instructorUid =
+        context.read<ApplicationState>().currentUser?.uid;
+    if (instructorUid == null || _student == null) return;
+
+    final dimensions = rubric.dimensions
+        .map((d) => SkillAssessmentDimension(
+              id: d.id,
+              name: d.name,
+              degree: _selectedDegrees[d.id] ?? 0,
+              maxDegrees: d.degrees.length,
+            ))
+        .toList();
+
+    final assessment = await SkillAssessmentFunctions.create(
+      courseId: courseId,
+      studentUid: _student!.uid,
+      instructorUid: instructorUid,
+      notes: _notesController.text,
+      dimensions: dimensions,
+    );
+
+    if (assessment != null) {
+      await UserFunctions.updateCourseSkillAssessment(
+        user: _student!,
+        courseId: courseId,
+        dimensions: dimensions,
+      );
+      if (mounted) {
+        Navigator.pushReplacementNamed(
+          context,
+          NavigationEnum.instructorClipboard.route,
+          arguments:
+              InstructorClipboardArgument(_student!.id, _student!.uid),
+        );
+      }
+    }
+  }
+}

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_header_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_header_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_assessment.dart';
+import 'package:social_learning/data/user.dart' as model;
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart';
+
+/// Top card for the skill assessment page containing profile photo,
+/// prior assessment radar, current assessment radar, and notes field.
+class SkillAssessmentHeaderCard extends StatelessWidget {
+  final model.User student;
+  final SkillAssessment? latestAssessment;
+  final List<SkillAssessmentDimension> currentDimensions;
+  final TextEditingController notesController;
+
+  const SkillAssessmentHeaderCard({
+    super.key,
+    required this.student,
+    required this.latestAssessment,
+    required this.currentDimensions,
+    required this.notesController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomCard(
+      title: 'Create a skill assessment for ${student.displayName}',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final itemSize = constraints.maxWidth / 3;
+              return Row(
+                children: [
+                  SizedBox(
+                    width: itemSize,
+                    height: itemSize,
+                    child: Center(
+                      child: ProfileImageWidgetV2.fromUser(
+                        student,
+                        maxRadius: itemSize / 2,
+                      ),
+                    ),
+                  ),
+                  SizedBox(
+                    width: itemSize,
+                    height: itemSize,
+                    child: Center(
+                      child: latestAssessment != null
+                          ? RadarWidget(
+                              assessment: latestAssessment!,
+                              size: itemSize,
+                              showLabels: true,
+                              drawPolygon: true,
+                              fillColor: Colors.blue.withOpacity(0.3),
+                            )
+                          : const Text(
+                              'No prior\nassessment',
+                              textAlign: TextAlign.center,
+                            ),
+                    ),
+                  ),
+                  SizedBox(
+                    width: itemSize,
+                    height: itemSize,
+                    child: Center(
+                      child: RadarWidget(
+                        dimensions: currentDimensions,
+                        size: itemSize,
+                        showLabels: true,
+                        drawPolygon: true,
+                        fillColor: Colors.blue.withOpacity(0.3),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: notesController,
+            minLines: 3,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              labelText: 'Notes',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+
+/// Card representing a single skill dimension with degree selectors and description.
+class SkillDimensionCard extends StatelessWidget {
+  final SkillDimension dimension;
+  final int? selectedDegree;
+  final int? previousDegree;
+  final ValueChanged<int> onDegreeSelected;
+
+  const SkillDimensionCard({
+    super.key,
+    required this.dimension,
+    required this.selectedDegree,
+    required this.previousDegree,
+    required this.onDegreeSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDowngrade = selectedDegree != null &&
+        previousDegree != null &&
+        selectedDegree! < previousDegree!;
+    SkillDegree? selected;
+    if (selectedDegree != null) {
+      selected =
+          dimension.degrees.firstWhere((d) => d.degree == selectedDegree);
+    }
+
+    return CustomCard(
+      title: dimension.name,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: dimension.degrees.map((degree) {
+              final isSelected = selectedDegree == degree.degree;
+              final color = isSelected
+                  ? (isDowngrade
+                      ? Colors.red
+                      : Theme.of(context).colorScheme.primary)
+                  : null;
+              return Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2),
+                  child: OutlinedButton(
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: color,
+                      foregroundColor: isSelected ? Colors.white : null,
+                    ),
+                    onPressed: () => onDegreeSelected(degree.degree),
+                    child: Text(
+                      degree.name,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+          if (isDowngrade)
+            const Padding(
+              padding: EdgeInsets.only(top: 4),
+              child: Text(
+                'Warning: student is getting a dimension downgraded.',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          const SizedBox(height: 8),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.black54),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(selected?.description ?? ''),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/ui_constants/navigation_enum.dart
+++ b/lib/ui_foundation/ui_constants/navigation_enum.dart
@@ -28,6 +28,7 @@ enum NavigationEnum {
   onlineSessionReview('/online_session_review'),
   instructorDashBoard('/instructor_dashboard'),
   instructorClipboard('/instructor_clipboard'),
+  createSkillAssessment('/create_skill_assessment'),
   courseGeneration('/course_generation'),
   courseGenerationReview('/course_generation_review'),
   courseDesignerIntro('/course_designer_intro'),


### PR DESCRIPTION
## Summary
- rename instructor assessment view to CreateSkillAssessmentPage and load data asynchronously
- reuse RadarWidget for prior and in-progress assessments with responsive layout and CustomCards
- expose new create_skill_assessment route
- extract SkillAssessmentHeaderCard and SkillDimensionCard into helper_widgets/skill_assessment subpackage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b116dcaf84832eac3f0039b738db37