### PR TITLE
Use maxCompletionTokens with OpenAI Java client

### DIFF
--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/OpenAiService.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/OpenAiService.java
@@ -57,7 +57,7 @@ public class OpenAiService {
         ChatCompletionCreateParams.Builder b = ChatCompletionCreateParams.builder()
                 .model(chatModel)
                 .temperature(temperature)
-                .maxTokens(maxTokens);
+                .maxCompletionTokens(maxTokens);
 
         for (Map<String, String> msg : messagesInput) {
             String role    = msg.get("role");

--- a/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/openaidsl/OpenAiClientImpl.java
+++ b/java-server/src/main/java/com/playposse/learninglab/server/firebase_server/openaidsl/OpenAiClientImpl.java
@@ -36,7 +36,7 @@ public class OpenAiClientImpl implements OpenAiClient {
         // 1) Start the builder with model & sampling params :contentReference[oaicite:1]{index=1}
         var builder = ChatCompletionCreateParams.builder()
                 .model(config.model())
-                .maxTokens(config.maxTokens())
+                .maxCompletionTokens(config.maxTokens())
                 .temperature(config.temperature())
                 .topP(config.topP())
                 .presencePenalty(config.presencePenalty())


### PR DESCRIPTION
## Summary
- update OpenAI Java client calls to use `maxCompletionTokens` instead of deprecated `maxTokens`

## Testing
- `bash gradlew test` *(fails: UnsatisfiedDependencyException: DefaultCredentialsProvider)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b725f00318832eb42a524735769474