### PR TITLE
fix: make record lesson dialog scrollable

### DIFF
--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -412,6 +412,7 @@ class LessonDetailState extends State<LessonDetailPage> {
         builder: (context) {
           return AlertDialog(
             title: const Text("Record Lesson"),
+            scrollable: true,
             actions: [
               TextButton(
                 onPressed: () {


### PR DESCRIPTION
## Summary
- keep Record Lesson dialog actions visible by enabling scrolling when content overflows

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7904dc8c4832eac9488d4a432248f