### PR TITLE
Add skill assessment viewing page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'package:social_learning/ui_foundation/session_student_page.dart';
 import 'package:social_learning/ui_foundation/sign_in_page.dart';
 import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
 import 'package:social_learning/ui_foundation/create_skill_assessment_page.dart';
+import 'package:social_learning/ui_foundation/view_skill_assessment_page.dart';
 
 import 'firebase_options.dart';
 import 'ui_foundation/profile_page.dart';
@@ -175,6 +176,7 @@ class SocialLearningApp extends StatelessWidget {
         '/instructor_dashboard': (context) => const InstructorDashboardPage(),
         '/instructor_clipboard': (context) => const InstructorClipboardPage(),
         '/create_skill_assessment': (context) => const CreateSkillAssessmentPage(),
+        '/view_skill_assessment': (context) => const ViewSkillAssessmentPage(),
         '/course_generation': (context) => const CourseGenerationPage(),
         '/course_generation_review': (context) =>
             const CourseGenerationReviewPage(),

--- a/lib/ui_foundation/helper_widgets/skill_assessment/legacy_skill_dimension_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/legacy_skill_dimension_view_card.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_assessment.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+
+/// Displays a legacy skill dimension that no longer exists in the current rubric.
+class LegacySkillDimensionViewCard extends StatelessWidget {
+  final SkillAssessmentDimension dimension;
+
+  const LegacySkillDimensionViewCard({
+    super.key,
+    required this.dimension,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomCard(
+      title: dimension.name,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Icon(Icons.info_outline),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'This dimension no longer exists in the current rubric.',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text('Degree at time of assessment: '
+              '${dimension.degree}/${dimension.maxDegrees}'),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_view_header_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_view_header_card.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:social_learning/data/skill_assessment.dart';
+import 'package:social_learning/data/user.dart' as model;
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart';
+
+/// Card displaying a user's skill assessment with history controls.
+class SkillAssessmentViewHeaderCard extends StatelessWidget {
+  final model.User student;
+  final List<SkillAssessment> assessments;
+  final int currentIndex;
+  final Map<String, model.User> instructors;
+  final ValueChanged<int> onIndexChanged;
+
+  const SkillAssessmentViewHeaderCard({
+    super.key,
+    required this.student,
+    required this.assessments,
+    required this.currentIndex,
+    required this.instructors,
+    required this.onIndexChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final assessment = assessments[currentIndex];
+    final instructor = instructors[assessment.instructorUid];
+    return CustomCard(
+      title: 'Skill Assessment for ${student.displayName}',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              ProfileImageWidgetV2.fromUser(student, maxRadius: 40),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  student.displayName,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final size = constraints.maxWidth;
+              return RadarWidget(
+                assessment: assessment,
+                size: size,
+                showLabels: true,
+                drawPolygon: true,
+                fillColor: Colors.blue.withOpacity(0.3),
+              );
+            },
+          ),
+          if (assessments.length > 1)
+            Slider(
+              value: currentIndex.toDouble(),
+              min: 0,
+              max: (assessments.length - 1).toDouble(),
+              divisions: assessments.length - 1,
+              onChanged: (v) => onIndexChanged(v.round()),
+            ),
+          const SizedBox(height: 8),
+          Text(
+            '${DateFormat.yMMMd().format(assessment.createdAt.toDate())} - '
+            '${instructor?.displayName ?? ''}',
+          ),
+          const SizedBox(height: 8),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.black54),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              (assessment.notes ?? '').isEmpty
+                  ? 'No notes'
+                  : assessment.notes!,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+
+/// Displays a skill dimension with all degrees and highlights the selected one.
+class SkillDimensionViewCard extends StatelessWidget {
+  final SkillDimension dimension;
+  final int selectedDegree;
+
+  const SkillDimensionViewCard({
+    super.key,
+    required this.dimension,
+    required this.selectedDegree,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomCard(
+      title: dimension.name,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: dimension.degrees.map((deg) {
+          final isSelected = deg.degree == selectedDegree;
+          return Container(
+            margin: const EdgeInsets.symmetric(vertical: 4),
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? Theme.of(context).colorScheme.primary.withOpacity(0.1)
+                  : null,
+              border: Border.all(
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : Colors.black54,
+              ),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  deg.name,
+                  style: TextStyle(
+                    fontWeight:
+                        isSelected ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+                if (deg.description != null) ...[
+                  const SizedBox(height: 4),
+                  Text(deg.description!),
+                ],
+              ],
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+

--- a/lib/ui_foundation/ui_constants/navigation_enum.dart
+++ b/lib/ui_foundation/ui_constants/navigation_enum.dart
@@ -29,6 +29,7 @@ enum NavigationEnum {
   instructorDashBoard('/instructor_dashboard'),
   instructorClipboard('/instructor_clipboard'),
   createSkillAssessment('/create_skill_assessment'),
+  viewSkillAssessment('/view_skill_assessment'),
   courseGeneration('/course_generation'),
   courseGenerationReview('/course_generation_review'),
   courseDesignerIntro('/course_designer_intro'),

--- a/lib/ui_foundation/view_skill_assessment_page.dart
+++ b/lib/ui_foundation/view_skill_assessment_page.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/skill_assessment.dart';
+import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/data/user.dart' as model;
+import 'package:social_learning/data/data_helpers/skill_assessment_functions.dart';
+import 'package:social_learning/data/data_helpers/skill_rubrics_functions.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/create_skill_assessment_page.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/skill_assessment/skill_assessment_view_header_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/skill_assessment/legacy_skill_dimension_view_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+import 'package:social_learning/ui_foundation/instructor_clipboard_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// Arguments to navigate to [ViewSkillAssessmentPage].
+class ViewSkillAssessmentPageArgument {
+  final String studentUid;
+
+  const ViewSkillAssessmentPageArgument(this.studentUid);
+
+  static void navigateTo(BuildContext context, String studentUid) {
+    Navigator.pushNamed(
+      context,
+      NavigationEnum.viewSkillAssessment.route,
+      arguments: ViewSkillAssessmentPageArgument(studentUid),
+    );
+  }
+}
+
+class ViewSkillAssessmentPage extends StatefulWidget {
+  const ViewSkillAssessmentPage({super.key});
+
+  @override
+  State<ViewSkillAssessmentPage> createState() => _ViewSkillAssessmentPageState();
+}
+
+class _ViewSkillAssessmentPageState extends State<ViewSkillAssessmentPage> {
+  Future<_PageData>? _dataFuture;
+  int _index = 0;
+  bool _initializedIndex = false;
+
+  String? get _studentUidArg =>
+      (ModalRoute.of(context)?.settings.arguments
+              as ViewSkillAssessmentPageArgument?)
+          ?.studentUid;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _dataFuture ??= _loadData();
+  }
+
+  Future<_PageData> _loadData() async {
+    final appState = context.read<ApplicationState>();
+    final libraryState = context.read<LibraryState>();
+    final courseId = libraryState.selectedCourse?.id;
+    final currentUser =
+        appState.currentUser ?? await appState.currentUserBlocking;
+    final studentUid = _studentUidArg ?? currentUser?.uid;
+    if (courseId == null || studentUid == null) {
+      return _PageData(null, [], {}, null);
+    }
+
+    final studentFuture = _loadStudent(studentUid, currentUser);
+    final assessmentsFuture = _loadAssessments(courseId, studentUid);
+    final rubricFuture = _loadRubric(courseId);
+
+    final results = await Future.wait([
+      studentFuture,
+      assessmentsFuture,
+      rubricFuture,
+    ]);
+
+    final student = results[0] as model.User?;
+    final assessments = results[1] as List<SkillAssessment>;
+    assessments.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    final rubric = results[2] as SkillRubric?;
+
+    final instructors = await _loadInstructors(assessments);
+
+    return _PageData(student, assessments, instructors, rubric);
+  }
+
+  bool get _isInstructorView => _studentUidArg != null;
+
+  Future<bool> _handlePop(model.User? student) async {
+    if (_isInstructorView && student != null) {
+      Navigator.pushReplacementNamed(
+        context,
+        NavigationEnum.instructorClipboard.route,
+        arguments: InstructorClipboardArgument(student.id, student.uid),
+      );
+    } else {
+      Navigator.pushReplacementNamed(context, NavigationEnum.profile.route);
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = context.watch<ApplicationState>();
+    final libraryState = context.watch<LibraryState>();
+    final course = libraryState.selectedCourse;
+    final currentUser = appState.currentUser;
+    final showFab =
+        course != null && currentUser != null && course.creatorId == currentUser.id;
+
+    return Scaffold(
+      appBar: const LearningLabAppBar(title: 'Skill Assessment'),
+      bottomNavigationBar: BottomBarV2.build(context),
+      floatingActionButton: showFab
+          ? FloatingActionButton(
+              onPressed: () async {
+                final data = await _dataFuture;
+                final student = data?.student;
+                if (!mounted || student == null) return;
+                CreateSkillAssessmentPageArgument.navigateTo(
+                    context, student.id, student.uid);
+              },
+              tooltip: 'Create Assessment',
+              child: const Icon(Icons.add),
+            )
+          : null,
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: CustomUiConstants.framePage(
+          FutureBuilder<_PageData>(
+            future: _dataFuture,
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final data = snapshot.data!;
+              final student = data.student;
+              final assessments = data.assessments;
+              final rubric = data.rubric;
+              if (student == null || rubric == null || assessments.isEmpty) {
+                return const Text('No skill assessments found.');
+              }
+              if (!_initializedIndex) {
+                _index = assessments.length - 1;
+                _initializedIndex = true;
+              }
+              final assessment = assessments[_index];
+              return WillPopScope(
+                onWillPop: () => _handlePop(student),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SkillAssessmentViewHeaderCard(
+                      student: student,
+                      assessments: assessments,
+                      currentIndex: _index,
+                      instructors: data.instructors,
+                      onIndexChanged: (i) {
+                        setState(() => _index = i);
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    ..._buildDimensionWidgets(rubric, assessment),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildDimensionWidgets(
+      SkillRubric rubric, SkillAssessment assessment) {
+    final widgets = <Widget>[];
+    final rubricMap = {for (var d in rubric.dimensions) d.id: d};
+    final assessedIds = <String>{};
+
+    for (final assessDim in assessment.dimensions) {
+      assessedIds.add(assessDim.id);
+      final rubricDim = rubricMap[assessDim.id];
+      if (rubricDim != null) {
+        widgets.add(
+          SkillDimensionViewCard(
+            dimension: rubricDim,
+            selectedDegree: assessDim.degree,
+          ),
+        );
+      } else {
+        widgets.add(
+          LegacySkillDimensionViewCard(dimension: assessDim),
+        );
+      }
+    }
+
+    for (final dim in rubric.dimensions) {
+      if (!assessedIds.contains(dim.id)) {
+        widgets.add(
+          CustomCard(
+            title: dim.name,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                Icon(Icons.info_outline),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'This dimension did not exist at the time of assessing.',
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+    }
+
+    return widgets;
+  }
+
+  Future<model.User?> _loadStudent(
+      String studentUid, model.User? currentUser) async {
+    if (_studentUidArg == null) {
+      return currentUser;
+    }
+    return UserFunctions.getUserByUid(studentUid);
+  }
+
+  Future<List<SkillAssessment>> _loadAssessments(
+      String courseId, String studentUid) {
+    return SkillAssessmentFunctions.allForUser(
+        courseId: courseId, studentUid: studentUid);
+  }
+
+  Future<SkillRubric?> _loadRubric(String courseId) {
+    return SkillRubricsFunctions.loadForCourse(courseId);
+  }
+
+  Future<Map<String, model.User>> _loadInstructors(
+      List<SkillAssessment> assessments) async {
+    final instructorUids = assessments.map((a) => a.instructorUid).toSet();
+    final futures = instructorUids.map(UserFunctions.getUserByUid).toList();
+    final users = await Future.wait(futures);
+    final map = <String, model.User>{};
+    for (final user in users) {
+      map[user.uid] = user;
+    }
+    return map;
+  }
+}
+
+class _PageData {
+  final model.User? student;
+  final List<SkillAssessment> assessments;
+  final Map<String, model.User> instructors;
+  final SkillRubric? rubric;
+
+  _PageData(this.student, this.assessments, this.instructors, this.rubric);
+}


### PR DESCRIPTION
## Summary
- refactor skill assessment view to load student, assessments, and rubric in parallel
- extract SkillAssessmentViewHeaderCard for top summary card with radar and history slider
- handle rubric dimension changes by iterating over assessment data and showing legacy or missing dimension messages

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b72913df70832e81d50b2bbac38e20