### PR TITLE
Add EqualSplitRow widget for paired layout

### DIFF
--- a/lib/ui_foundation/helper_widgets/general/equal_split_row.dart
+++ b/lib/ui_foundation/helper_widgets/general/equal_split_row.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+
+/// A widget that displays two children side by side, each taking up half of the
+/// available width. The height of both children is constrained to match the
+/// natural height of the taller child.
+class EqualSplitRow extends StatelessWidget {
+  final Widget leftChild;
+  final Widget rightChild;
+
+  const EqualSplitRow({
+    super.key,
+    required this.leftChild,
+    required this.rightChild,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(child: leftChild),
+          Expanded(child: rightChild),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add EqualSplitRow widget for two equally sized children that match tallest height

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b799eba458832eb044d0c0c54877d5