### PR TITLE
Add mentor profile image to record lesson dialog

### DIFF
--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -941,9 +941,23 @@ class RecordDialogState extends State<RecordDialogContent> {
                     child: Text('Mentor:',
                         style: CustomTextStyles.getBody(context))),
                 Padding(
-                    padding: EdgeInsets.all(4),
-                    child:
-                        Text('You', style: CustomTextStyles.getBody(context))),
+                    padding: const EdgeInsets.all(4),
+                    child: Row(
+                      children: [
+                        Expanded(
+                            flex: 1,
+                            child: Padding(
+                                padding: const EdgeInsets.only(right: 4),
+                                child: AspectRatio(
+                                    aspectRatio: 1,
+                                    child: ProfileImageWidgetV2
+                                        .fromCurrentUser()))),
+                        Expanded(
+                            flex: 3,
+                            child: Text('You',
+                                style: CustomTextStyles.getBody(context))),
+                      ],
+                    )),
               ]),
               TableRow(children: [
                 Padding(
@@ -952,8 +966,7 @@ class RecordDialogState extends State<RecordDialogContent> {
                         style: CustomTextStyles.getBody(context))),
                 Padding(
                     padding: const EdgeInsets.all(4),
-                    child: SizedBox(
-                        width: 200, child: _buildLearnerAutocomplete())),
+                    child: _buildLearnerAutocomplete()),
               ]),
             ]),
         Column(


### PR DESCRIPTION
## Summary
- Display mentor's profile photo alongside "You" in the record lesson dialog, matching the learner row layout
- Remove fixed width so mentor and learner rows expand based on available space

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c0ed198832eb7406e3212dea1ca