### PR TITLE
Allow editing invitation code on CMS syllabus

### DIFF
--- a/lib/data/data_helpers/course_functions.dart
+++ b/lib/data/data_helpers/course_functions.dart
@@ -61,6 +61,13 @@ class CourseFunctions {
     });
   }
 
+  static Future<void> updateCourse(
+      String courseId, Map<String, dynamic> data) {
+    return FirestoreService.instance
+        .doc('/courses/$courseId')
+        .set(data, SetOptions(merge: true));
+  }
+
   static Future<Course?> findCourseByInvitationCode(String code) async {
     final snapshot = await FirestoreService.instance
         .collection('courses')

--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -488,6 +488,16 @@ class LibraryState extends ChangeNotifier {
     return course;
   }
 
+  Future<void> updateInvitationCode(String newCode) async {
+    var course = selectedCourse;
+    if (course == null) {
+      return;
+    }
+    course.invitationCode = newCode;
+    await CourseFunctions.updateCourse(course.id!, {'invitationCode': newCode});
+    notifyListeners();
+  }
+
   void deleteLevel(Level level) {
     int sortOrder = level.sortOrder;
     var levels = _levels;

--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -13,6 +13,7 @@ import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.da
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/edit_invitation_code_dialog.dart';
 
 class CmsSyllabusPage extends StatefulWidget {
   const CmsSyllabusPage({super.key});
@@ -67,9 +68,28 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
                           )),
                           if (libraryState.selectedCourse?.invitationCode !=
                               null)
-                            CustomUiConstants.getTextPadding(Text(
-                                'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
-                                style: CustomTextStyles.getBody(context))),
+                            CustomUiConstants.getTextPadding(Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
+                                  style: CustomTextStyles.getBody(context),
+                                ),
+                                IconButton(
+                                    icon: const Icon(Icons.edit, size: 20),
+                                    tooltip: 'Edit invitation code',
+                                    onPressed: () {
+                                      showDialog(
+                                          context: context,
+                                          builder: (_) => EditInvitationCodeDialog(
+                                                currentCode: libraryState
+                                                        .selectedCourse
+                                                        ?.invitationCode ??
+                                                    '',
+                                              ));
+                                    })
+                              ],
+                            )),
                           generateLevelList(context, libraryState),
                           InkWell(
                               onTap: () {

--- a/lib/ui_foundation/helper_widgets/edit_invitation_code_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/edit_invitation_code_dialog.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+
+class EditInvitationCodeDialog extends StatelessWidget {
+  final String currentCode;
+
+  const EditInvitationCodeDialog({super.key, required this.currentCode});
+
+  @override
+  Widget build(BuildContext context) {
+    final libraryState = Provider.of<LibraryState>(context, listen: false);
+
+    return ValueInputDialog(
+      'Edit invitation code',
+      currentCode,
+      'Invitation code',
+      'OK',
+      (value) {
+        if (value == null || value.trim().length < 3) {
+          return 'Code must be at least 3 characters';
+        }
+        return null;
+      },
+      (newCode) async {
+        if (await libraryState.doesInvitationCodeExist(newCode)) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Invitation code already exists')),
+          );
+          return;
+        }
+        libraryState.updateInvitationCode(newCode);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add edit pencil next to invitation code on CMS syllabus page
- Use ValueInputDialog via new EditInvitationCodeDialog widget to update and save invitation code
- Support invitation code updates in LibraryState and CourseFunctions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88d171b14832e95425fb0d1b78ea7