### PR TITLE
Fix LayoutBuilder intrinsic dimension error in record dialog

### DIFF
--- a/lib/ui_foundation/lesson_detail_page.dart
+++ b/lib/ui_foundation/lesson_detail_page.dart
@@ -993,8 +993,7 @@ class RecordDialogState extends State<RecordDialogContent> {
   }
 
   Widget _buildLearnerAutocomplete() {
-    return LayoutBuilder(builder: (context, constraints) {
-      return Autocomplete<User>(
+    return Autocomplete<User>(
       displayStringForOption: (user) => user.displayName,
       optionsBuilder: (TextEditingValue textEditingValue) async {
         if (textEditingValue.text.isEmpty) {
@@ -1043,13 +1042,13 @@ class RecordDialogState extends State<RecordDialogContent> {
         return SizedBox(key: _learnerFieldKey, width: double.infinity, child: child);
       },
       optionsViewBuilder: (context, onSelected, options) {
-        final width = _learnerFieldKey.currentContext?.size?.width ?? 0;
+        final width = _learnerFieldKey.currentContext?.size?.width ?? 200;
         return Align(
             alignment: Alignment.topLeft,
             child: Material(
                 elevation: 4,
                 child: SizedBox(
-                    width: constraints.maxWidth,
+                    width: width,
                     height: 200,
                     child: ListView.builder(
                         itemCount: options.length,
@@ -1083,7 +1082,6 @@ class RecordDialogState extends State<RecordDialogContent> {
         });
       },
     );
-    });
   }
 
   List<Row> _generateGraduationRequirementsChecks() {


### PR DESCRIPTION
## Summary
- replace `LayoutBuilder` with direct `Autocomplete` in record dialog to avoid intrinsic dimension errors inside `AlertDialog`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8933780f8832ebe1cce33426e72c2