### PR TITLE
Allow editing course titles from CMS syllabus page

### DIFF
--- a/lib/state/library_state.dart
+++ b/lib/state/library_state.dart
@@ -498,6 +498,16 @@ class LibraryState extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> updateCourseTitle(String newTitle) async {
+    var course = selectedCourse;
+    if (course == null) {
+      return;
+    }
+    course.title = newTitle;
+    await CourseFunctions.updateCourse(course.id!, {'title': newTitle});
+    notifyListeners();
+  }
+
   void deleteLevel(Level level) {
     int sortOrder = level.sortOrder;
     var levels = _levels;

--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -13,7 +13,8 @@ import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.da
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/edit_invitation_code_dialog.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/cms_syllabus/edit_invitation_code_dialog.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/cms_syllabus/edit_course_title_dialog.dart';
 
 class CmsSyllabusPage extends StatefulWidget {
   const CmsSyllabusPage({super.key});
@@ -62,9 +63,31 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
                           child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          CustomUiConstants.getTextPadding(Text(
-                            '${libraryState.selectedCourse?.title} Curriculum',
-                            style: CustomTextStyles.headline,
+                          CustomUiConstants.getTextPadding(Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  '${libraryState.selectedCourse?.title} Curriculum',
+                                  style: CustomTextStyles.headline,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              IconButton(
+                                icon:
+                                    const Icon(Icons.edit, size: 20, color: Colors.grey),
+                                tooltip: 'Edit course title',
+                                onPressed: () {
+                                  showDialog(
+                                      context: context,
+                                      builder: (_) => EditCourseTitleDialog(
+                                            currentTitle: libraryState
+                                                    .selectedCourse?.title ??
+                                                '',
+                                          ));
+                                },
+                              )
+                            ],
                           )),
                           if (libraryState.selectedCourse?.invitationCode !=
                               null)
@@ -76,7 +99,8 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
                                   style: CustomTextStyles.getBody(context),
                                 ),
                                 IconButton(
-                                    icon: const Icon(Icons.edit, size: 20),
+                                    icon: const Icon(Icons.edit,
+                                        size: 20, color: Colors.grey),
                                     tooltip: 'Edit invitation code',
                                     onPressed: () {
                                       showDialog(

--- a/lib/ui_foundation/helper_widgets/cms_syllabus/edit_course_title_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/cms_syllabus/edit_course_title_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
+
+class EditCourseTitleDialog extends StatelessWidget {
+  final String currentTitle;
+
+  const EditCourseTitleDialog({super.key, required this.currentTitle});
+
+  @override
+  Widget build(BuildContext context) {
+    final libraryState = Provider.of<LibraryState>(context, listen: false);
+
+    return ValueInputDialog(
+      'Edit course title',
+      currentTitle,
+      'Course title',
+      'OK',
+      (value) {
+        if (value == null || value.trim().length < 3) {
+          return 'Title must be at least 3 characters';
+        }
+        if (libraryState.availableCourses.any((course) =>
+            course.title.toLowerCase() == value.trim().toLowerCase() &&
+            course.id != libraryState.selectedCourse?.id)) {
+          return 'Course title already exists';
+        }
+        return null;
+      },
+      (newTitle) {
+        libraryState.updateCourseTitle(newTitle.trim());
+      },
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/cms_syllabus/edit_invitation_code_dialog.dart
+++ b/lib/ui_foundation/helper_widgets/cms_syllabus/edit_invitation_code_dialog.dart
@@ -21,16 +21,16 @@ class EditInvitationCodeDialog extends StatelessWidget {
         if (value == null || value.trim().length < 3) {
           return 'Code must be at least 3 characters';
         }
+        if (libraryState.availableCourses.any((course) =>
+            (course.invitationCode ?? '').toLowerCase() ==
+                value.trim().toLowerCase() &&
+            course.id != libraryState.selectedCourse?.id)) {
+          return 'Invitation code already exists';
+        }
         return null;
       },
-      (newCode) async {
-        if (await libraryState.doesInvitationCodeExist(newCode)) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Invitation code already exists')),
-          );
-          return;
-        }
-        libraryState.updateInvitationCode(newCode);
+      (newCode) {
+        libraryState.updateInvitationCode(newCode.trim());
       },
     );
   }


### PR DESCRIPTION
## Summary
- Add pencil icon to edit course title on the CMS syllabus page
- Implement `EditCourseTitleDialog` using `ValueInputDialog`
- Move invitation code dialog and new course title dialog into dedicated `cms_syllabus` folder
- Add `updateCourseTitle` handler in `LibraryState`
- Validate title and invitation code within dialog fields and style edit icons grey

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89454b638832e950f7dea6f7d52fa