### PR TITLE
Count only active session participants

### DIFF
--- a/lib/state/firestore_subscription/session_participants_subscription.dart
+++ b/lib/state/firestore_subscription/session_participants_subscription.dart
@@ -51,14 +51,15 @@ class SessionParticipantsSubscription
 
   void _updateParticipantCount(
       session, List<SessionParticipant> sessionParticipants) {
-    if ((session != null) &&
-        (sessionParticipants.length != session?.participantCount)) {
+    final activeCount =
+        sessionParticipants.where((p) => p.isActive).length;
+    if ((session != null) && (activeCount != session?.participantCount)) {
       // Update the session participant count.
       FirebaseFirestore.instance
           .collection('sessions')
           .doc(session.id)
-          .update({'participantCount': sessionParticipants.length});
-      print('_updateParticipantCount(${sessionParticipants.length}');
+          .update({'participantCount': activeCount});
+      print('_updateParticipantCount($activeCount)');
     }
   }
 


### PR DESCRIPTION
## Summary
- count only active session participants when updating session document
- log updated active participant count

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b0f4458c832e8378e1d5950267a8