### PR TITLE
Filter inactive session participants from dropdowns

### DIFF
--- a/lib/ui_foundation/helper_widgets/mentee_table_cell.dart
+++ b/lib/ui_foundation/helper_widgets/mentee_table_cell.dart
@@ -18,8 +18,18 @@ class MenteeTableCell extends UserTableCell {
 
   @override
   List<DropdownMenuEntry<User>> getSelectableUsers() {
+    // Derive the set of inactive user UIDs.
+    Set<String> inactiveUserUids =
+        organizerSessionState.sessionParticipants
+            .where((participant) => !participant.isActive)
+            .map((participant) => participant.participantUid)
+            .toSet();
+
     // Get all users.
     List<User> users = List.of(organizerSessionState.participantUsers);
+
+    // Remove inactive users.
+    users.removeWhere((user) => inactiveUserUids.contains(user.uid));
 
     // Remove users that are already in pairings.
     List<SessionPairing>? currentRound = organizerSessionState.lastRound;

--- a/lib/ui_foundation/helper_widgets/mentor_table_cell.dart
+++ b/lib/ui_foundation/helper_widgets/mentor_table_cell.dart
@@ -18,8 +18,18 @@ class MentorTableCell extends UserTableCell {
 
   @override
   List<DropdownMenuEntry<User>> getSelectableUsers() {
+    // Derive the set of inactive user UIDs.
+    Set<String> inactiveUserUids =
+        organizerSessionState.sessionParticipants
+            .where((participant) => !participant.isActive)
+            .map((participant) => participant.participantUid)
+            .toSet();
+
     // Get all users.
     List<User> users = List.of(organizerSessionState.participantUsers);
+
+    // Remove inactive users.
+    users.removeWhere((user) => inactiveUserUids.contains(user.uid));
 
     // Remove users that are already in pairings.
     List<SessionPairing>? currentRound = organizerSessionState.lastRound;


### PR DESCRIPTION
## Summary
- exclude inactive session participants from mentor dropdown
- exclude inactive session participants from mentee dropdown

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0fda2b0832ea2715c899ed99df7