### PR TITLE
Add SessionParticipantFunctions to centralize Firestore access

### DIFF
--- a/lib/data/data_helpers/session_participant_functions.dart
+++ b/lib/data/data_helpers/session_participant_functions.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/session_participant.dart';
+
+class SessionParticipantFunctions {
+  static Query<Map<String, dynamic>> queryBySessionId(
+      CollectionReference<Map<String, dynamic>> collectionReference,
+      String sessionId) {
+    return collectionReference.where('sessionId',
+        isEqualTo: docRef('sessions', sessionId));
+  }
+
+  static Future<DocumentReference<Map<String, dynamic>>> createParticipant({
+    required String sessionId,
+    required String userId,
+    required String userUid,
+    required String courseId,
+    required bool isInstructor,
+    bool isActive = true,
+    int teachCount = 0,
+    int learnCount = 0,
+  }) {
+    return FirestoreService.instance.collection('sessionParticipants').add({
+      'sessionId': docRef('sessions', sessionId),
+      'participantId': docRef('users', userId),
+      'participantUid': userUid,
+      'courseId': docRef('courses', courseId),
+      'isInstructor': isInstructor,
+      'isActive': isActive,
+      'teachCount': teachCount,
+      'learnCount': learnCount,
+    });
+  }
+
+  static Future<SessionParticipant?> findActiveForUser(String userId) async {
+    final userRef = docRef('users', userId);
+    final snapshot = await FirestoreService.instance
+        .collection('sessionParticipants')
+        .where('participantId', isEqualTo: userRef)
+        .where('isActive', isEqualTo: true)
+        .get();
+    if (snapshot.docs.isEmpty) {
+      return null;
+    }
+    return SessionParticipant.fromSnapshot(snapshot.docs.first);
+  }
+}
+

--- a/lib/state/firestore_subscription/session_participants_subscription.dart
+++ b/lib/state/firestore_subscription/session_participants_subscription.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:social_learning/data/session_participant.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/data/data_helpers/session_participant_functions.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/firestore_subscription/firestore_list_subscription.dart';
 import 'package:social_learning/state/firestore_subscription/participant_users_subscription.dart';
@@ -85,21 +86,16 @@ class SessionParticipantsSubscription
       return element.participantUid == currentUser?.uid;
     });
     print('containsSelf: $containsSelf; this.uid: ${currentUser?.uid}');
-    if (!containsSelf) {
+    if (!containsSelf && currentUser != null) {
       // TODO: This seems to create entries too aggressively.
       print('Student added itself as a participant');
-      FirebaseFirestore.instance.collection('sessionParticipants').add({
-        'sessionId': FirebaseFirestore.instance.doc('/sessions/${session.id}'),
-        'participantId':
-            FirebaseFirestore.instance.doc('/users/${currentUser?.id}'),
-        'participantUid': currentUser?.uid,
-        'courseId':
-            FirebaseFirestore.instance.doc('/courses/${session.courseId.id}'),
-        'isInstructor': currentUser?.isAdmin,
-        'isActive': true,
-        'teachCount': 0,
-        'learnCount': 0,
-      });
+      SessionParticipantFunctions.createParticipant(
+        sessionId: session.id!,
+        userId: currentUser.id,
+        userUid: currentUser.uid,
+        courseId: session.courseId.id,
+        isInstructor: currentUser.isAdmin,
+      );
     }
   }
 }

--- a/lib/state/organizer_session_state.dart
+++ b/lib/state/organizer_session_state.dart
@@ -16,6 +16,7 @@ import 'package:social_learning/state/firestore_subscription/session_pairings_su
 import 'package:social_learning/state/firestore_subscription/session_participants_subscription.dart';
 import 'package:social_learning/state/firestore_subscription/session_subscription.dart';
 import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/data/data_helpers/session_participant_functions.dart';
 
 class OrganizerSessionState extends ChangeNotifier {
   final LibraryState _libraryState;
@@ -154,19 +155,13 @@ class OrganizerSessionState extends ChangeNotifier {
 
     // Create organizer participant.
     print('before creating participant');
-    DocumentReference<Map<String, dynamic>> participantDoc =
-        await FirebaseFirestore.instance
-            .collection('sessionParticipants')
-            .add(<String, dynamic>{
-      'sessionId': FirebaseFirestore.instance.doc('/sessions/$sessionId'),
-      'participantId': FirebaseFirestore.instance.doc('/users/${organizer.id}'),
-      'participantUid': organizer.uid,
-      'courseId': FirebaseFirestore.instance.doc('/courses/${course.id}'),
-      'isInstructor': organizer.isAdmin,
-      'isActive': true,
-      'teachCount': 0,
-      'learnCount': 0,
-    });
+    await SessionParticipantFunctions.createParticipant(
+      sessionId: sessionId,
+      userId: organizer.id,
+      userUid: organizer.uid,
+      courseId: course.id,
+      isInstructor: organizer.isAdmin,
+    );
     print('after creating participant');
 
     // Listen to session changes.
@@ -183,8 +178,8 @@ class OrganizerSessionState extends ChangeNotifier {
     _sessionSubscription.resubscribe(() => '/sessions/$sessionId');
 
     _sessionParticipantsSubscription.resubscribe((collectionReference) =>
-        collectionReference.where('sessionId',
-            isEqualTo: FirebaseFirestore.instance.doc('/sessions/$sessionId')));
+        SessionParticipantFunctions.queryBySessionId(
+            collectionReference, sessionId));
 
     _sessionPairingSubscription.resubscribe((collectionReference) =>
         collectionReference.where('sessionId',


### PR DESCRIPTION
## Summary
- add SessionParticipantFunctions for Firestore helpers
- update session participant subscription to use new helpers
- refactor organizer and student session states to route queries through helpers

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b9628ca0832e9e73452754fe174e