### PR TITLE
feat: allow students to leave session

### DIFF
--- a/lib/data/data_helpers/session_participant_functions.dart
+++ b/lib/data/data_helpers/session_participant_functions.dart
@@ -1,0 +1,28 @@
+import 'package:social_learning/data/data_helpers/reference_helper.dart';
+import 'package:social_learning/data/firestore_service.dart';
+import 'package:social_learning/data/session_participant.dart';
+
+class SessionParticipantFunctions {
+  /// Fetches the active [SessionParticipant] document for the given [userId].
+  static Future<SessionParticipant?> getActiveParticipant(String userId) async {
+    var userRef = docRef('users', userId);
+    var snapshot = await FirestoreService.instance
+        .collection('sessionParticipants')
+        .where('participantId', isEqualTo: userRef)
+        .where('isActive', isEqualTo: true)
+        .limit(1)
+        .get();
+    if (snapshot.docs.isEmpty) {
+      return null;
+    }
+    return SessionParticipant.fromSnapshot(snapshot.docs.first);
+  }
+
+  /// Marks the participant with the given [participantId] as inactive.
+  static Future<void> deactivate(String participantId) {
+    return FirestoreService.instance
+        .collection('sessionParticipants')
+        .doc(participantId)
+        .update({'isActive': false});
+  }
+}

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -5,10 +5,12 @@ import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_round_card.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class SessionStudentArgument {
   String sessionId;
@@ -39,6 +41,23 @@ class SessionStudentState extends State<SessionStudentPage> {
 
     return Scaffold(
       appBar: const LearningLabAppBar(title: 'Learning Lab'),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await DialogUtils.showConfirmationDialog(
+            context,
+            'Leave Session',
+            'Are you sure you want to leave the session?',
+            () async {
+              await Provider.of<StudentSessionState>(context, listen: false)
+                  .leaveSession();
+              if (context.mounted) {
+                NavigationEnum.sessionHome.navigateClean(context);
+              }
+            },
+          );
+        },
+        child: const Icon(Icons.exit_to_app, color: Colors.grey),
+      ),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,


### PR DESCRIPTION
## Summary
- add SessionParticipantFunctions to encapsulate session participant queries and updates
- use functions in StudentSessionState to deactivate the user and reset session
- exit button now shows a confirmation dialog and navigates back to session home
- await session checks after making `_checkForOngoingSession` async

## Testing
- `flutter pub get` *(fails: firebase_ui_auth ^2.0.0 requires intl 0.19.0 but intl ^0.20.2 is used)*
- `flutter analyze` *(fails: firebase_ui_auth ^2.0.0 requires intl 0.19.0 but intl ^0.20.2 is used)*
- `flutter test` *(fails: firebase_ui_auth ^2.0.0 requires intl 0.19.0 but intl ^0.20.2 is used)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b11caba8832e9ac74b85dcd5bfdf