### PR TITLE
Warn when AI rubric generation would overwrite existing data

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_info_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/skill_rubric/skill_rubric_info_card.dart
@@ -10,13 +10,13 @@ class SkillRubricInfoCard extends StatelessWidget {
 
   Future<void> _onAIPressed(BuildContext context) async {
     final state = context.read<CourseDesignerState>();
-    final hasDegrees =
-        state.skillRubric?.dimensions.any((d) => d.degrees.isNotEmpty) ?? false;
-    if (hasDegrees) {
+    final hasDimensions =
+        state.skillRubric?.dimensions.isNotEmpty ?? false;
+    if (hasDimensions) {
       await DialogUtils.showInfoDialog(
         context,
         'AI skill rubric generation',
-        'This AI function can only be used for an empty skill rubric.\n\nDelete your existing skill degrees to proceed.',
+        'AI generation is only available for an empty skill rubric.\n\nIt will overwrite all existing dimensions and degrees.',
         () {},
       );
     } else {


### PR DESCRIPTION
## Summary
- Prevent AI skill rubric generation when dimensions already exist
- Inform users that AI generation only works on empty rubrics and overwrites existing data

## Testing
- `flutter pub get` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68c0ce90dbdc832e8c704558f8a116b7