### PR TITLE
Handle session participant reactivation

### DIFF
--- a/lib/data/data_helpers/session_participant_functions.dart
+++ b/lib/data/data_helpers/session_participant_functions.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+class SessionParticipantFunctions {
+  static Future<DocumentReference<Map<String, dynamic>>> createSessionParticipant({
+    required String sessionId,
+    required String userId,
+    required String participantUid,
+    required String courseId,
+    required bool isInstructor,
+  }) {
+    return FirestoreService.instance.collection('sessionParticipants').add({
+      'sessionId': FirestoreService.instance.doc('/sessions/$sessionId'),
+      'participantId': FirestoreService.instance.doc('/users/$userId'),
+      'participantUid': participantUid,
+      'courseId': FirestoreService.instance.doc('/courses/$courseId'),
+      'isInstructor': isInstructor,
+      'isActive': true,
+      'teachCount': 0,
+      'learnCount': 0,
+    });
+  }
+
+  static Future<void> updateSessionParticipant(
+      String participantId, Map<String, dynamic> data) {
+    return FirestoreService.instance
+        .doc('/sessionParticipants/$participantId')
+        .set(data, SetOptions(merge: true));
+  }
+}


### PR DESCRIPTION
## Summary
- reactivate existing session participant document instead of always creating a new one
- encapsulate session participant Firestore access in a dedicated functions class

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b28f7740832e8c792fe45bc6b9b3