### PR TITLE
Handle participant reactivation in sessions

### DIFF
--- a/lib/data/data_helpers/session_participant_functions.dart
+++ b/lib/data/data_helpers/session_participant_functions.dart
@@ -45,5 +45,11 @@ class SessionParticipantFunctions {
     }
     return SessionParticipant.fromSnapshot(snapshot.docs.first);
   }
+
+  static Future<void> updateIsActive(String participantId, bool isActive) {
+    return FirestoreService.instance
+        .doc('/sessionParticipants/$participantId')
+        .update({'isActive': isActive});
+  }
 }
 


### PR DESCRIPTION
## Summary
- Add helper to toggle session participant activity in SessionParticipantFunctions
- Reactivate existing session participant and warn if duplicate records exist

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dc54c234832eb2ef82556344f0f2