### PR TITLE
Include exercises in rubric degree descriptions

### DIFF
--- a/lib/data/data_helpers/skill_rubrics_functions.dart
+++ b/lib/data/data_helpers/skill_rubrics_functions.dart
@@ -58,11 +58,14 @@ class SkillRubricsFunctions {
         final degrees = <SkillDegree>[];
         for (int i = 0; i < dim.degrees.length; i++) {
           final deg = dim.degrees[i];
+          final exerciseText = deg.lessons.map((e) => "- $e").join("\n");
+          final fullDescription =
+              [deg.criteria, exerciseText].where((s) => s.trim().isNotEmpty).join("\n\n");
           degrees.add(SkillDegree(
             id: _firestore.collection(_collectionPath).doc().id,
             degree: i + 1,
             name: deg.name,
-            description: deg.criteria,
+            description: fullDescription,
             lessonRefs: [],
           ));
         }

--- a/test/skill_rubrics_functions_test.dart
+++ b/test/skill_rubrics_functions_test.dart
@@ -1,0 +1,45 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/cloud_functions/skill_rubric_generation_response.dart';
+import 'package:social_learning/data/data_helpers/skill_rubrics_functions.dart';
+import 'package:social_learning/data/firestore_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fake;
+
+  setUp(() {
+    fake = FakeFirebaseFirestore();
+    FirestoreService.instance = fake;
+  });
+
+  tearDown(() {
+    FirestoreService.instance = null;
+  });
+
+  test('replaceRubricForCourse includes lessons in degree description', () async {
+    await fake.collection('courses').doc('c1').set({'title': 't'});
+    final generated = GeneratedSkillDimension(
+      name: 'Dimension',
+      description: '',
+      degrees: [
+        GeneratedSkillDegree(
+          name: 'Degree 1',
+          criteria: 'Criteria text',
+          lessons: ['Exercise 1', 'Exercise 2'],
+        ),
+      ],
+    );
+
+    await SkillRubricsFunctions.replaceRubricForCourse(
+      courseId: 'c1',
+      generated: [generated],
+    );
+
+    final loaded = await SkillRubricsFunctions.loadForCourse('c1');
+    final description = loaded!.dimensions.first.degrees.first.description;
+    final exerciseText = ['Exercise 1', 'Exercise 2'].map((e) => '- $e').join('\n');
+    final expected =
+        ['Criteria text', exerciseText].where((s) => s.trim().isNotEmpty).join('\n\n');
+    expect(description, expected);
+  });
+}


### PR DESCRIPTION
## Summary
- show generated lessons as bullet lists in rubric degree descriptions
- test that replaceRubricForCourse stores lessons in description

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0df6776cc832e950769211f88b8c6