### PR TITLE
Abbreviate long dimension headings in rubric

### DIFF
--- a/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/decomposed_course_designer_card.dart
@@ -48,9 +48,12 @@ class DecomposedCourseDesignerCard {
       );
     } else {
       children.add(
-        Text(
-          title,
-          style: CourseDesignerTheme.cardHeaderTextStyle,
+        Expanded(
+          child: Text(
+            title,
+            style: CourseDesignerTheme.cardHeaderTextStyle,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
       );
 


### PR DESCRIPTION
## Summary
- Prevent long rubric dimension titles from pushing action icons off-screen
- Apply ellipsis overflow handling for dimension headers

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e02867d8832e9c2209cbfec3ba55