### PR TITLE
feat: allow students to leave sessions

### DIFF
--- a/lib/state/student_session_state.dart
+++ b/lib/state/student_session_state.dart
@@ -104,7 +104,8 @@ class StudentSessionState extends ChangeNotifier {
         }
       }
     }).catchError((error) {
-      print('Error getting active participants for the current session: $error');
+      print(
+          'Error getting active participants for the current session: $error');
       _resetSession();
     });
   }
@@ -124,6 +125,28 @@ class StudentSessionState extends ChangeNotifier {
     // TODO: Add self as participant if needed.
     // TODO: Subscribe to participants.
     // TODO: Figure out the bug why sessions aren't visible on the first try.
+  }
+
+  Future<void> leaveSession() async {
+    final currentUser = _applicationState.currentUser;
+    if (currentUser != null) {
+      try {
+        SessionParticipant? participant;
+        try {
+          participant = sessionParticipants
+              .firstWhere((p) => p.participantId.id == currentUser.id);
+        } catch (_) {
+          participant = null;
+        }
+        if (participant != null && participant.id != null) {
+          await SessionParticipantFunctions.updateIsActive(
+              participant.id!, false);
+        }
+      } catch (e) {
+        debugPrint('Error leaving session: $e');
+      }
+    }
+    _resetSession();
   }
 
   _resetSession() {

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -7,6 +7,7 @@ import 'package:social_learning/state/student_session_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_round_card.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
@@ -40,6 +41,23 @@ class SessionStudentState extends State<SessionStudentPage> {
     return Scaffold(
       appBar: const LearningLabAppBar(title: 'Learning Lab'),
       bottomNavigationBar: BottomBarV2.build(context),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          DialogUtils.showConfirmationDialog(
+            context,
+            'Leave Session',
+            'Are you sure you want to leave the session?',
+            () {
+              Provider.of<StudentSessionState>(context, listen: false)
+                  .leaveSession()
+                  .then((_) {
+                Navigator.of(context).pushReplacementNamed('/session_home');
+              });
+            },
+          );
+        },
+        child: const Icon(Icons.exit_to_app, color: Colors.grey),
+      ),
       body: Align(
         alignment: Alignment.topCenter,
         child: CustomUiConstants.framePage(


### PR DESCRIPTION
## Summary
- Add leaveSession in StudentSessionState to deactivate participant and reset session
- Add exit button with confirmation dialog to SessionStudentPage that navigates to session home

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `snap install flutter --classic` *(fails: command not found)*
- `flutter pub get`
- `flutter analyze` *(545 issues found)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e490f104832e8ee305bbe46f3dc2