### PR TITLE
fix: ignore sessions from other courses

### DIFF
--- a/lib/state/organizer_session_state.dart
+++ b/lib/state/organizer_session_state.dart
@@ -91,24 +91,14 @@ class OrganizerSessionState extends ChangeNotifier {
             'Got active session where this user is the organiser: ${snapshot.docs.length}, incomplete: ${snapshot.metadata.hasPendingWrites}');
         if ((snapshot.size > 0) && !snapshot.metadata.hasPendingWrites) {
           var session = Session.fromQuerySnapshot(snapshot.docs.first);
-          String sessionId = session.id!;
-          // _currentSession = session;
-
-          _subscribeToSession(sessionId);
-          _sessionSubscription.loadItemManually(session);
-
-          // Check if the right course is selected and switch if necessary.
-          if (_libraryState.selectedCourse?.id != session.courseId.id) {
-            print(
-                'Need to select course: ${_libraryState.availableCourses.length}');
-            // TODO: There is a timing bug. Courses won't have loaded yet at startup.
-            var courses = _libraryState.availableCourses
-                .where((course) => course.id == session.courseId.id);
-            if (courses.isNotEmpty) {
-              _libraryState.selectedCourse = courses.first;
-              print(
-                  'Auto-selected course because of active session: ${courses.first.title}');
-            }
+          // Only enter the session if it belongs to the currently selected course.
+          var selectedCourseId = _libraryState.selectedCourse?.id;
+          if (selectedCourseId == session.courseId.id) {
+            String sessionId = session.id!;
+            _subscribeToSession(sessionId);
+            _sessionSubscription.loadItemManually(session);
+          } else {
+            print('Active session found for a different course; ignoring.');
           }
         }
       }).onError((error, stackTrace) {


### PR DESCRIPTION
## Summary
- remove automatic course switching when reconnecting to an active session
- ignore reconnecting to active sessions in different courses

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18cdfb734832ebf444ed4ddcbf623