### PR TITLE
Align radar outer ring with profile belt color

### DIFF
--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart
@@ -12,6 +12,7 @@ import 'package:social_learning/data/user.dart';
 import 'package:social_learning/state/application_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_styles.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart';
 
 /// Unified version of [ProfileImageWidget] and [ProfileImageByUserIdWidget].
@@ -236,32 +237,33 @@ class _ProfileImageWidgetV2State extends State<ProfileImageWidgetV2> {
         _createCircleAvatar(context, maxDisplayRadius, availableWidth);
 
     if (borderColor != null) {
+      final borderWidth = CustomUiStyles.profileBorderWidth;
       avatar = Container(
           decoration: BoxDecoration(
               shape: BoxShape.circle,
-              border: Border.all(color: borderColor, width: 2.0)),
+              border: Border.all(color: borderColor, width: borderWidth)),
           child: avatar);
     }
     return avatar;
   }
 
   Widget _buildRadarAvatar(Color? borderColor, double maxDisplayRadius) {
+    final borderWidth = CustomUiStyles.profileBorderWidth;
     final diameter = maxDisplayRadius * 2;
     Widget radar = SizedBox(
       width: diameter,
       height: diameter,
       child: RadarWidget(
-        user: _user!,
-        size: diameter,
-        showLabels: false,
-      ),
+          user: _user!,
+          size: diameter,
+          showLabels: false),
     );
     radar = ClipOval(child: radar);
     if (borderColor != null) {
       radar = Container(
           decoration: BoxDecoration(
               shape: BoxShape.circle,
-              border: Border.all(color: borderColor, width: 2.0)),
+              border: Border.all(color: borderColor, width: borderWidth)),
           child: radar);
     }
     return radar;

--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart
@@ -6,7 +6,9 @@ import 'package:social_learning/data/skill_assessment.dart';
 import 'package:social_learning/data/skill_rubric.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/data_helpers/skill_rubrics_functions.dart';
+import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
 import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_styles.dart';
 
 class RadarWidget extends StatelessWidget {
   final User? user;
@@ -89,6 +91,17 @@ class RadarWidget extends StatelessWidget {
     }
 
     dims ??= [];
+    Color? outerColor;
+    if (user != null) {
+      final course = context.watch<LibraryState>().selectedCourse;
+      if (course != null) {
+        final prof = user!.getCourseProficiency(course);
+        if (prof != null) {
+          outerColor = BeltColorFunctions.getBeltColor(prof.proficiency);
+        }
+      }
+    }
+
     return CustomPaint(
       size: Size.square(size),
       painter: _RadarPainter(
@@ -97,6 +110,9 @@ class RadarWidget extends StatelessWidget {
         mainLineWidth: mainLineWidth,
         supportColor: supportColor,
         supportLineWidth: supportLineWidth,
+        outerColor: outerColor,
+        outerLineWidth:
+            outerColor != null ? CustomUiStyles.profileBorderWidth : supportLineWidth,
         showLabels: showLabels,
         drawPolygon: polygon,
         fillColor: fillColor,
@@ -111,6 +127,8 @@ class _RadarPainter extends CustomPainter {
   final double mainLineWidth;
   final Color supportColor;
   final double supportLineWidth;
+  final Color? outerColor;
+  final double? outerLineWidth;
   final bool showLabels;
   final bool drawPolygon;
   final Color fillColor;
@@ -121,6 +139,8 @@ class _RadarPainter extends CustomPainter {
     required this.mainLineWidth,
     required this.supportColor,
     required this.supportLineWidth,
+    this.outerColor,
+    this.outerLineWidth,
     required this.showLabels,
     required this.drawPolygon,
     required this.fillColor,
@@ -134,12 +154,16 @@ class _RadarPainter extends CustomPainter {
       ..color = supportColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = supportLineWidth;
+    final outerPaint = Paint()
+      ..color = outerColor ?? supportColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = outerLineWidth ?? supportLineWidth;
     final mainPaint = Paint()
       ..color = mainColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = mainLineWidth;
 
-    canvas.drawCircle(center, radius, supportPaint);
+    canvas.drawCircle(center, radius, outerPaint);
 
     final count = dimensions.length;
     if (count == 0) {
@@ -216,6 +240,8 @@ class _RadarPainter extends CustomPainter {
         old.mainLineWidth != mainLineWidth ||
         old.supportColor != supportColor ||
         old.supportLineWidth != supportLineWidth ||
+        old.outerColor != outerColor ||
+        old.outerLineWidth != outerLineWidth ||
         old.showLabels != showLabels ||
         old.drawPolygon != drawPolygon ||
         old.fillColor != fillColor;

--- a/lib/ui_foundation/ui_constants/custom_ui_styles.dart
+++ b/lib/ui_foundation/ui_constants/custom_ui_styles.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+class CustomUiStyles {
+  static const double profileBorderWidth = 2.0;
+}


### PR DESCRIPTION
## Summary
- add `CustomUiStyles.profileBorderWidth` for a shared avatar/radar border width
- color radar's outer ring from the user's proficiency and apply shared width automatically
- use the shared width in the profile image widget for both image and radar modes

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e499dac4832e84787236c1965c22