### PR TITLE
Keep skill assessment header visible

### DIFF
--- a/lib/ui_foundation/create_skill_assessment_page.dart
+++ b/lib/ui_foundation/create_skill_assessment_page.dart
@@ -111,6 +111,7 @@ class _CreateSkillAssessmentPageState extends State<CreateSkillAssessmentPage> {
         alignment: Alignment.topCenter,
         child: CustomUiConstants.framePage(
           enableCreatorGuard: true,
+          enableScrolling: false,
           Consumer2<CourseDesignerState, LibraryState>(
             builder: (context, designerState, libraryState, _) {
               final rubric = designerState.skillRubric;
@@ -145,18 +146,22 @@ class _CreateSkillAssessmentPageState extends State<CreateSkillAssessmentPage> {
                     notesController: _notesController,
                   ),
                   const SizedBox(height: 8),
-                  ...rubric.dimensions.map((dim) {
-                    return SkillDimensionCard(
-                      dimension: dim,
-                      selectedDegree: _selectedDegrees[dim.id],
-                      previousDegree: _previousDegrees[dim.id],
-                      onDegreeSelected: (degree) {
-                        setState(() {
-                          _selectedDegrees[dim.id] = degree;
-                        });
-                      },
-                    );
-                  }).toList(),
+                  Expanded(
+                    child: ListView(
+                      children: rubric.dimensions.map((dim) {
+                        return SkillDimensionCard(
+                          dimension: dim,
+                          selectedDegree: _selectedDegrees[dim.id],
+                          previousDegree: _previousDegrees[dim.id],
+                          onDegreeSelected: (degree) {
+                            setState(() {
+                              _selectedDegrees[dim.id] = degree;
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  ),
                 ],
               );
             },


### PR DESCRIPTION
## Summary
- Keep skill assessment header card visible by pinning it outside the scrollable list
- Place `enableCreatorGuard` and `enableScrolling` before the `framePage` child for consistent parameter ordering

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f19a519c832e9c79f6ccfbefc06b