### PR TITLE
Show dimension description above degree buttons

### DIFF
--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
@@ -35,11 +35,19 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
       orElse: () => widget.dimension.degrees.first,
     );
 
+    final dimensionDescription = widget.dimension.description;
+    final hasDimensionDescription =
+        dimensionDescription != null && dimensionDescription.trim().isNotEmpty;
+
     return CustomCard(
       title: widget.dimension.name,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (hasDimensionDescription) ...[
+            _buildDescriptionBox(dimensionDescription),
+            const SizedBox(height: 8),
+          ],
           Row(
             children: widget.dimension.degrees.map((degree) {
               final isAssessment = degree.degree == widget.selectedDegree;
@@ -80,17 +88,21 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
             }).toList(),
           ),
           const SizedBox(height: 8),
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.black54),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(selected.description ?? ''),
-          ),
+          _buildDescriptionBox(selected.description),
         ],
       ),
+    );
+  }
+
+  Widget _buildDescriptionBox(String? text) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.black54),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(text ?? ''),
     );
   }
 }


### PR DESCRIPTION
## Summary
- display the dimension description above the degree selection buttons in the skill dimension view card
- reuse a shared description box builder so both descriptions use the same layout treatment

## Testing
- flutter pub get *(fails: `flutter` command not found)*
- flutter analyze *(fails: `flutter` command not found)*
- flutter test *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c86d09a7c8832ebb042335e237ee8b