### PR TITLE
Add labels to skill dimension description boxes

### DIFF
--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
@@ -45,7 +45,10 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (hasDimensionDescription) ...[
-            _buildDescriptionBox(dimensionDescription),
+            _buildDescriptionBox(
+              dimensionDescription,
+              label: 'Dimension description',
+            ),
             const SizedBox(height: 8),
           ],
           Row(
@@ -88,21 +91,30 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
             }).toList(),
           ),
           const SizedBox(height: 8),
-          _buildDescriptionBox(selected.description),
+          _buildDescriptionBox(
+            selected.description,
+            label: 'Degree description',
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildDescriptionBox(String? text) {
-    return Container(
+  Widget _buildDescriptionBox(
+    String? text, {
+    required String label,
+  }) {
+    final value = text ?? '';
+    return SizedBox(
       width: double.infinity,
-      padding: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        border: Border.all(color: Colors.black54),
-        borderRadius: BorderRadius.circular(4),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+        ),
+        isEmpty: value.trim().isEmpty,
+        child: Text(value),
       ),
-      child: Text(text ?? ''),
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace the plain container around skill descriptions with an InputDecorator to get Material-style borders and labels
- label the boxes as "Dimension description" and "Degree description" for clarity when reviewing skill details

## Testing
- flutter analyze *(fails: command not found: flutter)*
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c8816996a0832e9e4be0d160607ee3