### PR TITLE
Simplify radar belt border defaults

### DIFF
--- a/lib/data/data_helpers/belt_color_functions.dart
+++ b/lib/data/data_helpers/belt_color_functions.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:social_learning/data/user.dart';
+import 'package:social_learning/state/library_state.dart';
 
 class BeltColorFunctions {
   static const List<Color> colors = [
@@ -53,5 +55,26 @@ class BeltColorFunctions {
     final Color lowerColor = colors[lowerIndex];
     final Color upperColor = colors[upperIndex];
     return Color.lerp(lowerColor, upperColor, interpolationFactor)!;
+  }
+
+  static Color? getSelectedCourseBeltColor({
+    required LibraryState libraryState,
+    User? user,
+  }) {
+    if (user == null) {
+      return null;
+    }
+
+    final course = libraryState.selectedCourse;
+    if (course == null) {
+      return null;
+    }
+
+    final proficiency = user.getCourseProficiency(course);
+    if (proficiency == null) {
+      return null;
+    }
+
+    return getBeltColor(proficiency.proficiency);
   }
 }

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_view_header_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_assessment_view_header_card.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/data_helpers/belt_color_functions.dart';
 import 'package:social_learning/data/skill_assessment.dart';
 import 'package:social_learning/data/user.dart' as model;
 import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/state/library_state.dart';
 
 /// Card displaying a user's skill assessment with history controls.
 class SkillAssessmentViewHeaderCard extends StatelessWidget {
@@ -29,6 +31,11 @@ class SkillAssessmentViewHeaderCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final assessment = assessments[currentIndex];
     final instructor = instructors[assessment.instructorUid];
+    final libraryState = context.watch<LibraryState>();
+    final beltColor = BeltColorFunctions.getSelectedCourseBeltColor(
+      libraryState: libraryState,
+      user: student,
+    );
     return CustomCard(
       title: 'Skill Assessment for ${student.displayName}',
       child: Column(
@@ -58,6 +65,7 @@ class SkillAssessmentViewHeaderCard extends StatelessWidget {
                       showLabels: true,
                       drawPolygon: true,
                       fillColor: Colors.blue.withOpacity(0.3),
+                      outerColor: beltColor,
                     );
                   },
                 ),

--- a/lib/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart
+++ b/lib/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart
@@ -19,6 +19,7 @@ class RadarWidget extends StatelessWidget {
   final double mainLineWidth;
   final Color supportColor;
   final double supportLineWidth;
+  final Color? outerColor;
   final bool showLabels;
   final bool drawPolygon;
   final Color fillColor;
@@ -33,6 +34,7 @@ class RadarWidget extends StatelessWidget {
     this.mainLineWidth = 2,
     this.supportColor = Colors.grey,
     this.supportLineWidth = 1,
+    this.outerColor,
     this.showLabels = true,
     this.drawPolygon = true,
     this.fillColor = Colors.transparent,
@@ -43,12 +45,13 @@ class RadarWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     List<SkillAssessmentDimension>? dims = dimensions;
     bool polygon = drawPolygon;
+    final libraryState = context.watch<LibraryState>();
 
     if (dims == null) {
       if (assessment != null) {
         dims = assessment!.dimensions;
       } else if (user != null) {
-        final course = context.watch<LibraryState>().selectedCourse;
+        final course = libraryState.selectedCourse;
         if (course == null) {
           return SizedBox(width: size, height: size);
         }
@@ -71,6 +74,14 @@ class RadarWidget extends StatelessWidget {
                       )
                       .toList() ??
                   [];
+              var outerColor = this.outerColor;
+              outerColor ??= BeltColorFunctions.getSelectedCourseBeltColor(
+                libraryState: libraryState,
+                user: user,
+              );
+              final double outerLineWidth = outerColor != null
+                  ? CustomUiConstants.profileBorderWidth
+                  : supportLineWidth;
               return CustomPaint(
                 size: Size.square(size),
                 painter: _RadarPainter(
@@ -79,6 +90,8 @@ class RadarWidget extends StatelessWidget {
                   mainLineWidth: mainLineWidth,
                   supportColor: supportColor,
                   supportLineWidth: supportLineWidth,
+                  outerColor: outerColor,
+                  outerLineWidth: outerLineWidth,
                   showLabels: showLabels,
                   drawPolygon: false,
                   fillColor: fillColor,
@@ -91,16 +104,14 @@ class RadarWidget extends StatelessWidget {
     }
 
     dims ??= [];
-    Color? outerColor;
-    if (user != null) {
-      final course = context.watch<LibraryState>().selectedCourse;
-      if (course != null) {
-        final prof = user!.getCourseProficiency(course);
-        if (prof != null) {
-          outerColor = BeltColorFunctions.getBeltColor(prof.proficiency);
-        }
-      }
-    }
+    var outerColor = this.outerColor;
+    outerColor ??= BeltColorFunctions.getSelectedCourseBeltColor(
+      libraryState: libraryState,
+      user: user,
+    );
+    final double outerLineWidth = outerColor != null
+        ? CustomUiConstants.profileBorderWidth
+        : supportLineWidth;
 
     return CustomPaint(
       size: Size.square(size),
@@ -111,8 +122,7 @@ class RadarWidget extends StatelessWidget {
         supportColor: supportColor,
         supportLineWidth: supportLineWidth,
         outerColor: outerColor,
-        outerLineWidth:
-            outerColor != null ? CustomUiConstants.profileBorderWidth : supportLineWidth,
+        outerLineWidth: outerLineWidth,
         showLabels: showLabels,
         drawPolygon: polygon,
         fillColor: fillColor,
@@ -128,7 +138,7 @@ class _RadarPainter extends CustomPainter {
   final Color supportColor;
   final double supportLineWidth;
   final Color? outerColor;
-  final double? outerLineWidth;
+  final double outerLineWidth;
   final bool showLabels;
   final bool drawPolygon;
   final Color fillColor;
@@ -140,7 +150,7 @@ class _RadarPainter extends CustomPainter {
     required this.supportColor,
     required this.supportLineWidth,
     this.outerColor,
-    this.outerLineWidth,
+    required this.outerLineWidth,
     required this.showLabels,
     required this.drawPolygon,
     required this.fillColor,
@@ -157,7 +167,7 @@ class _RadarPainter extends CustomPainter {
     final outerPaint = Paint()
       ..color = outerColor ?? supportColor
       ..style = PaintingStyle.stroke
-      ..strokeWidth = outerLineWidth ?? supportLineWidth;
+      ..strokeWidth = outerLineWidth;
     final mainPaint = Paint()
       ..color = mainColor
       ..style = PaintingStyle.stroke


### PR DESCRIPTION
## Summary
- allow `BeltColorFunctions.getSelectedCourseBeltColor` to safely handle a null user before checking course proficiency
- remove the `outerLineWidth` override from `RadarWidget` while computing the constant width whenever a belt color is available
- call the shared belt color helper directly from `RadarWidget` to avoid duplicating null checks

## Testing
- flutter analyze *(fails: `flutter` command not available in container)*
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87e0c79b8832e97ba1d5f8daa1a82