### PR TITLE
Toggle skill degree description

### DIFF
--- a/lib/ui_foundation/helper_widgets/skill_assessment/collapsible_description.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/collapsible_description.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// A tappable description that previews two lines and keeps its expanded state
+/// even when the underlying text changes.
+class CollapsibleDescription extends StatefulWidget {
+  final String text;
+
+  const CollapsibleDescription({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  State<CollapsibleDescription> createState() => _CollapsibleDescriptionState();
+}
+
+class _CollapsibleDescriptionState extends State<CollapsibleDescription> {
+  bool _isExpanded = false;
+
+  void _toggle() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _toggle,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.black54),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          widget.text,
+          maxLines: _isExpanded ? null : 2,
+          overflow: _isExpanded ? TextOverflow.visible : TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:social_learning/data/skill_rubric.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
 
+import 'collapsible_description.dart';
+
 /// Card representing a single skill dimension with degree selectors and description.
 class SkillDimensionCard extends StatelessWidget {
   final SkillDimension dimension;
@@ -19,14 +21,19 @@ class SkillDimensionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final selectedDegree = this.selectedDegree;
+    final previousDegree = this.previousDegree;
     final isDowngrade = selectedDegree != null &&
         previousDegree != null &&
-        selectedDegree! < previousDegree!;
+        selectedDegree < previousDegree;
     SkillDegree? selected;
     if (selectedDegree != null) {
-      selected =
-          dimension.degrees.firstWhere((d) => d.degree == selectedDegree);
+      selected = dimension.degrees
+          .firstWhere((d) => d.degree == selectedDegree);
     }
+
+    final description = selected?.description ?? '';
+    final hasDescription = description.trim().isNotEmpty;
 
     return CustomCard(
       title: dimension.name,
@@ -72,16 +79,12 @@ class SkillDimensionCard extends StatelessWidget {
                 style: TextStyle(color: Colors.red),
               ),
             ),
-          const SizedBox(height: 8),
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.black54),
-              borderRadius: BorderRadius.circular(4),
+          if (hasDescription) ...[
+            const SizedBox(height: 8),
+            CollapsibleDescription(
+              text: description,
             ),
-            child: Text(selected?.description ?? ''),
-          ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- hide the degree description panel until a degree is chosen on the create skill assessment page
- extract a CollapsibleDescription widget so the two-line preview and expand/collapse behavior is encapsulated outside SkillDimensionCard
- keep expanded descriptions open when switching between degrees so the full text stays visible

## Testing
- flutter pub get *(fails: `flutter` is not installed in the container)*
- flutter analyze *(fails: `flutter` is not installed in the container)*
- flutter test *(fails: `flutter` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c883b4d674832e867bfb54014f1611