### PR TITLE
Enhance skill assessment practice list interactions

### DIFF
--- a/lib/state/student_state.dart
+++ b/lib/state/student_state.dart
@@ -124,6 +124,56 @@ class StudentState extends ChangeNotifier {
 
   int getTeachCount() => _teachRecords?.length ?? 0;
 
+  Map<String, int> getSelectedCourseLessonStatuses() {
+    _init();
+
+    final selectedCourse = _libraryState.selectedCourse;
+    final courseId = selectedCourse?.id;
+    if (selectedCourse == null || courseId == null) {
+      return const {};
+    }
+
+    final lessonStatuses = <String, int>{};
+
+    void updateStatus(String lessonId, int newStatus) {
+      final current = lessonStatuses[lessonId];
+      if (current == null || newStatus > current) {
+        lessonStatuses[lessonId] = newStatus;
+      }
+    }
+
+    final learnRecords = _learnRecords;
+    if (learnRecords != null) {
+      for (final record in learnRecords) {
+        if (record.courseId.id != courseId) {
+          continue;
+        }
+
+        final lessonId = record.lessonId.id;
+        updateStatus(lessonId, record.isGraduation ? 2 : 1);
+      }
+    }
+
+    final teachRecords = _teachRecords;
+    if (teachRecords != null) {
+      for (final record in teachRecords) {
+        if (!record.isGraduation) {
+          continue;
+        }
+        if (record.courseId.id != courseId) {
+          continue;
+        }
+
+        final lessonId = record.lessonId.id;
+        if ((lessonStatuses[lessonId] ?? 0) >= 2) {
+          updateStatus(lessonId, 3);
+        }
+      }
+    }
+
+    return Map.unmodifiable(lessonStatuses);
+  }
+
   /// Returns 0 for never practice, 1 for practiced, 2 for graduated, and 3 for
   /// taught.
   int getLessonStatus(Lesson lesson) {

--- a/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
+++ b/lib/ui_foundation/helper_widgets/skill_assessment/skill_dimension_view_card.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/data/lesson.dart';
 import 'package:social_learning/data/skill_rubric.dart';
+import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
+import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 /// Displays a skill dimension with degree buttons and shows the description of
 /// the currently selected degree. The degree that was part of the assessment is
@@ -8,11 +14,13 @@ import 'package:social_learning/ui_foundation/helper_widgets/custom_card.dart';
 class SkillDimensionViewCard extends StatefulWidget {
   final SkillDimension dimension;
   final int selectedDegree;
+  final Map<String, int> lessonStatuses;
 
   const SkillDimensionViewCard({
     super.key,
     required this.dimension,
     required this.selectedDegree,
+    required this.lessonStatuses,
   });
 
   @override
@@ -29,11 +37,33 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
   }
 
   @override
+  void didUpdateWidget(covariant SkillDimensionViewCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final hasDegreeChanged =
+        oldWidget.selectedDegree != widget.selectedDegree ||
+            oldWidget.dimension.id != widget.dimension.id;
+    if (hasDegreeChanged && _viewedDegree != widget.selectedDegree) {
+      setState(() {
+        _viewedDegree = widget.selectedDegree;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final selected = widget.dimension.degrees.firstWhere(
       (d) => d.degree == _viewedDegree,
       orElse: () => widget.dimension.degrees.first,
     );
+
+    final libraryState = context.watch<LibraryState>();
+    final lessons = <Lesson>[];
+    for (final ref in selected.lessonRefs) {
+      final lesson = libraryState.findLesson(ref.id);
+      if (lesson != null && lesson.id != null) {
+        lessons.add(lesson);
+      }
+    }
 
     return CustomCard(
       title: widget.dimension.name,
@@ -50,7 +80,8 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
                 background = Theme.of(context).colorScheme.primary;
                 foreground = Colors.white;
               } else if (isViewing) {
-                background = Theme.of(context).colorScheme.primary.withOpacity(0.1);
+                background =
+                    Theme.of(context).colorScheme.primary.withOpacity(0.1);
               }
               return Expanded(
                 child: Padding(
@@ -89,8 +120,83 @@ class _SkillDimensionViewCardState extends State<SkillDimensionViewCard> {
             ),
             child: Text(selected.description ?? ''),
           ),
+          if (lessons.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              'Practice',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 4),
+            ...lessons.map((lesson) => _buildLessonRow(context, lesson)),
+          ],
         ],
       ),
+    );
+  }
+
+  Widget _buildLessonRow(BuildContext context, Lesson lesson) {
+    final status = _statusForLesson(lesson);
+    final style = _textStyleForStatus(context, status);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text('•', style: style),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              lesson.title,
+              style: style,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton(
+            icon: const Icon(Icons.start, size: 20),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Start lesson',
+            onPressed: () => _openLesson(lesson),
+          ),
+        ],
+      ),
+    );
+  }
+
+  int _statusForLesson(Lesson lesson) {
+    final lessonId = lesson.id;
+    if (lessonId == null) {
+      return 0;
+    }
+    return widget.lessonStatuses[lessonId] ?? 0;
+  }
+
+  TextStyle _textStyleForStatus(BuildContext context, int status) {
+    final base = CustomTextStyles.getBody(context) ??
+        Theme.of(context).textTheme.bodyMedium ??
+        const TextStyle();
+    if (status >= 2) {
+      return CustomTextStyles.getFullyLearned(context) ??
+          base.copyWith(color: CustomTextStyles.fullyLearnedColor);
+    }
+    if (status == 1) {
+      return base.copyWith(color: Theme.of(context).colorScheme.onSurface);
+    }
+    return base.copyWith(color: Theme.of(context).disabledColor);
+  }
+
+  void _openLesson(Lesson lesson) {
+    final lessonId = lesson.id;
+    if (lessonId == null) {
+      return;
+    }
+    Navigator.pushNamed(
+      context,
+      NavigationEnum.lessonDetail.route,
+      arguments: LessonDetailArgument(lessonId),
     );
   }
 }


### PR DESCRIPTION
## Summary
- optimize the StudentState lesson status helper to build the map in a single pass over practice and teaching records
- fetch mentee practice records alongside other skill assessment data and pass lesson status maps into each skill dimension card
- show a per-lesson practice list with consistent start icons and progress-based text colors inside the skill assessment card without extra progress enums

## Testing
- `flutter pub get` *(fails: `flutter` command is not available in the container environment)*
- `flutter analyze` *(fails: `flutter` command is not available in the container environment)*
- `flutter test` *(fails: `flutter` command is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86de8a730832e87151bf1e0aaee89