### PR TITLE
Add syllabus step to course designer flow

### DIFF
--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -6,12 +6,12 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/cms_lesson_page.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/edit_level_title_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/one_time_banner.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/cms_syllabus/edit_invitation_code_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/cms_syllabus/edit_course_title_dialog.dart';
@@ -28,12 +28,17 @@ class CmsSyllabusPage extends StatefulWidget {
 class CmsSyllabusState extends State<CmsSyllabusPage> {
   @override
   Widget build(BuildContext context) {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
     return Consumer<LibraryState>(
       builder: (context, libraryState, child) {
         return Scaffold(
-          appBar: LearningLabAppBar(
-            actions: InstructorNavActions.createActions(context),
+          key: scaffoldKey,
+          appBar: CourseDesignerAppBar(
+            title: 'Syllabus',
+            scaffoldKey: scaffoldKey,
+            currentNav: NavigationEnum.cmsSyllabus,
           ),
+          drawer: const CourseDesignerDrawer(),
           bottomNavigationBar: BottomBarV2.build(context),
           floatingActionButton: FloatingActionButton(
             onPressed: () {

--- a/lib/ui_foundation/course_designer_session_plan_page.dart
+++ b/lib/ui_foundation/course_designer_session_plan_page.dart
@@ -87,10 +87,9 @@ class _CourseDesignerSessionPlanPageState
       bottomNavigationBar: BottomBarV2.build(context),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO: Navigate to the next page.
-          // NavigationEnum.courseDesignerSomething.navigateCleanDelayed(context);
+          NavigationEnum.cmsSyllabus.navigateCleanDelayed(context);
         },
-        tooltip: 'Next Page',
+        tooltip: 'Syllabus',
         child: const Icon(Icons.arrow_forward),
       ),
       body: Align(

--- a/lib/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart
@@ -23,6 +23,7 @@ class CourseDesignerDrawer extends StatelessWidget {
     _CurriculumStep(
         'Objectives', NavigationEnum.courseDesignerLearningObjectives),
     _CurriculumStep('Session Plan', NavigationEnum.courseDesignerSessionPlan),
+    _CurriculumStep('Syllabus', NavigationEnum.cmsSyllabus),
     // _CurriculumStep('Scoping', NavigationEnum.courseGenerationReview),
     // _CurriculumStep('Skill Dimensions', NavigationEnum.cmsLesson),
     // _CurriculumStep('Learning Outcomes', NavigationEnum.instructorClipboard),

--- a/lib/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart
+++ b/lib/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart
@@ -42,6 +42,10 @@ class CourseDesignerTabBar extends StatefulWidget implements PreferredSizeWidget
         icon: Icons.event,
         nav: NavigationEnum.courseDesignerSessionPlan,
         label: 'Session Plan'),
+    _TabInfo(
+        icon: Icons.library_books_outlined,
+        nav: NavigationEnum.cmsSyllabus,
+        label: 'Syllabus'),
   ];
 
   /// Returns the tab index for a [NavigationEnum].


### PR DESCRIPTION
## Summary
- update the CMS syllabus page to use the course designer app bar and drawer so it matches the flow
- add a Syllabus step with a library-books icon to the course designer tab bar and drawer navigation
- wire the session plan page’s forward navigation to open the syllabus step

## Testing
- flutter pub get *(fails: flutter not installed in container)*
- flutter analyze *(fails: flutter not installed in container)*
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ca03e5c0832e87cfc7b85f7a28c5