### PR TITLE
Remove course designer entry icon from app bar

### DIFF
--- a/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
+++ b/lib/ui_foundation/helper_widgets/general/course_designer_app_bar.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_drawer.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/course_designer/course_designer_tab_bar.dart';
-import 'package:social_learning/ui_foundation/ui_constants/instructor_nav_actions.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 /// App bar used across CourseDesigner pages.
-/// Includes drawer toggle, course switch icon, and instructor navigation icons.
+/// Includes drawer toggle and course switch icon.
 class CourseDesignerAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final GlobalKey<ScaffoldState> scaffoldKey;
@@ -28,7 +27,6 @@ class CourseDesignerAppBar extends StatelessWidget implements PreferredSizeWidge
           onPressed: () => NavigationEnum.home.navigateClean(context),
           icon: const Icon(Icons.swap_horiz),
         ),
-        ...InstructorNavActions.createActions(context),
       ],
       bottom: currentNav == null
           ? null


### PR DESCRIPTION
## Summary
- remove the Course Designer navigation icon from the course designer app bar so only the course switcher remains

## Testing
- flutter pub get *(fails: `flutter` command not found in container)*
- flutter analyze *(fails: `flutter` command not found in container)*
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d4f189f0832ea49b3801c5e1e0ac