### PR TITLE
Make invitation code selectable

### DIFF
--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -104,9 +104,11 @@ class CmsSyllabusState extends State<CmsSyllabusPage> {
                             child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Text(
-                                  'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
-                                  style: CustomTextStyles.getBody(context),
+                                Flexible(
+                                  child: SelectableText(
+                                    'Invitation code: ${libraryState.selectedCourse?.invitationCode}',
+                                    style: CustomTextStyles.getBody(context),
+                                  ),
                                 ),
                                 IconButton(
                                     icon: const Icon(Icons.edit,


### PR DESCRIPTION
## Summary
- wrap the invitation code label on the CMS syllabus page with a `SelectableText`
- allow instructors to copy and paste the invitation code while preserving the existing styling

## Testing
- `flutter analyze` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b0af06fc832ebcbf4b3fff00a73a