### PR TITLE
Enable skill assessment navigation from profile radar

### DIFF
--- a/lib/ui_foundation/profile_page.dart
+++ b/lib/ui_foundation/profile_page.dart
@@ -23,6 +23,7 @@ import 'package:social_learning/data/data_helpers/skill_rubrics_functions.dart';
 import 'package:social_learning/data/skill_rubric.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/radar_widget.dart';
+import 'package:social_learning/ui_foundation/view_skill_assessment_page.dart';
 
 import '../state/application_state.dart';
 import 'ui_constants/navigation_enum.dart';
@@ -119,7 +120,8 @@ class ProfilePageState extends State<ProfilePage> {
                           flex: 1,
                           child: GestureDetector(
                             onTap: () {
-                              // TODO: Navigate to skill assessments page.
+                              ViewSkillAssessmentPageArgument.navigateTo(
+                                  context, currentUser.uid);
                             },
                             child: LayoutBuilder(
                               builder: (context, constraints) {


### PR DESCRIPTION
## Summary
- wire up the profile radar tap handler to open the skill assessment view for the current user
- add the necessary import for the skill assessment navigation helper

## Testing
- `flutter pub get` *(fails: flutter command not found in container)*
- `flutter analyze` *(fails: flutter command not found in container)*
- `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b5d86250832e842591121042c6b2