### PR TITLE
Ensure join pending flag managed around participant creation

### DIFF
--- a/lib/state/firestore_subscription/session_participants_subscription.dart
+++ b/lib/state/firestore_subscription/session_participants_subscription.dart
@@ -93,15 +93,26 @@ class SessionParticipantsSubscription
     if (matching.isEmpty) {
       if (!_isJoinPending) {
         _isJoinPending = true;
-        print('Student added itself as a participant');
+        print('Student added itself as a participant (pending join)');
         SessionParticipantFunctions.createParticipant(
           sessionId: session.id!,
           userId: currentUser.id,
           userUid: currentUser.uid,
           courseId: session.courseId.id,
           isInstructor: currentUser.isAdmin,
-        );
-        _isJoinPending = false;
+        )
+            .then((documentReference) {
+          print(
+              'Participant document created for ${currentUser.uid}: ${documentReference.id}');
+        }).catchError((error, stackTrace) {
+          print(
+              'Failed to create participant document for ${currentUser.uid}: $error');
+        }).whenComplete(() {
+          _isJoinPending = false;
+          print('Join attempt completed for ${currentUser.uid}');
+        });
+      } else {
+        print('Join already pending for ${currentUser.uid}, skipping.');
       }
       return;
     }


### PR DESCRIPTION
## Summary
- keep the join pending flag set until the participant creation request completes
- log join lifecycle events to highlight successful participant document creation and failures

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b9556b1c832ebcdeabe1404e4419