### PR TITLE
Register navigation route for playground page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,7 @@ import 'package:social_learning/ui_foundation/online_session_active_page.dart';
 import 'package:social_learning/ui_foundation/online_session_review_page.dart';
 import 'package:social_learning/ui_foundation/online_session_waiting_room_page.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
+import 'package:social_learning/ui_foundation/playground_page.dart';
 import 'package:social_learning/ui_foundation/profile_comparison_page.dart';
 import 'package:social_learning/ui_foundation/session_create_page.dart';
 import 'package:social_learning/ui_foundation/session_create_warning_page.dart';
@@ -196,6 +197,7 @@ class SocialLearningApp extends StatelessWidget {
             const CourseDesignerLearningObjectivesPage(),
         '/course_designer_session_plan': (context) =>
             const CourseDesignerSessionPlanPage(),
+        '/playground': (context) => const PlaygroundPage(),
       },
     );
   }

--- a/lib/ui_foundation/playground_page.dart
+++ b/lib/ui_foundation/playground_page.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+class PlaygroundPage extends StatefulWidget {
+  const PlaygroundPage({super.key});
+
+  @override
+  State<PlaygroundPage> createState() => _PlaygroundPageState();
+}
+
+class _PlaygroundPageState extends State<PlaygroundPage> {
+  final List<String> _entries = <String>[];
+  final TextEditingController _textController = TextEditingController();
+  final FocusNode _textFocusNode = FocusNode();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _textFocusNode.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit(String rawValue) {
+    final String value = rawValue.trim();
+    if (value.isEmpty) {
+      _textController.clear();
+      _textFocusNode.requestFocus();
+      return;
+    }
+
+    setState(() {
+      _entries.add(value);
+    });
+
+    _textController.clear();
+    _textFocusNode.requestFocus();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Playground'),
+      ),
+      body: ListView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+        itemCount: _entries.length + 1,
+        itemBuilder: (BuildContext context, int index) {
+          if (index < _entries.length) {
+            return _PlaygroundEntry(text: _entries[index]);
+          }
+
+          return Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Row(
+              children: <Widget>[
+                const SizedBox(width: 60, height: 60),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: TextField(
+                    controller: _textController,
+                    focusNode: _textFocusNode,
+                    onSubmitted: _handleSubmit,
+                    textInputAction: TextInputAction.done,
+                    decoration: const InputDecoration(
+                      labelText: 'Add an entry',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PlaygroundEntry extends StatelessWidget {
+  const _PlaygroundEntry({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Container(
+            width: 60,
+            height: 60,
+            decoration: const BoxDecoration(
+              color: Colors.blueGrey,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- import the PlaygroundPage into the main application
- register a /playground route so the experimental page is directly accessible

## Testing
- not run (environment only provides source changes)

------
https://chatgpt.com/codex/tasks/task_e_68d6e24a6470832e922661212b3507e7