### PR TITLE
Ensure course designer state resets on sign out

### DIFF
--- a/lib/state/application_state.dart
+++ b/lib/state/application_state.dart
@@ -9,6 +9,7 @@ import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/data_helpers/user_functions.dart';
 import 'package:social_learning/state/available_session_state.dart';
+import 'package:social_learning/state/course_designer_state.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/state/online_session_state.dart';
 import 'package:social_learning/state/organizer_session_state.dart';
@@ -185,6 +186,10 @@ class ApplicationState extends ChangeNotifier {
     LibraryState libraryState =
         Provider.of<LibraryState>(context, listen: false);
     libraryState.signOut();
+
+    final courseDesignerState =
+        Provider.of<CourseDesignerState>(context, listen: false);
+    courseDesignerState.signOut();
 
     StudentState studentState =
         Provider.of<StudentState>(context, listen: false);

--- a/lib/state/course_designer_state.dart
+++ b/lib/state/course_designer_state.dart
@@ -199,6 +199,13 @@ class CourseDesignerState extends ChangeNotifier {
     }
   }
 
+  void signOut() {
+    _activeCourse = null;
+    _status = CourseDesignerStateStatus.uninitialized;
+    _initCompleter = Completer<void>();
+    clear();
+  }
+
   void clear() {
     _activeCourse = _libraryState.selectedCourse;
     courseProfile = null;


### PR DESCRIPTION
## Summary
- add a signOut helper to CourseDesignerState that clears cached data and resets initialization state
- update ApplicationState.signOut to reset the course designer state after clearing the library state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6eb78c7fc832e8d1de91b217ad14a