### PR TITLE
Limit instructor dashboard nav usage

### DIFF
--- a/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_app_bar.dart
+++ b/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_app_bar.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:social_learning/state/library_state.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// App bar for instructor flow pages.
+/// Mirrors the shared Learning Lab app bar while hosting the flow tab bar.
+class InstructorDashboardAppBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  final NavigationEnum currentNav;
+  final String? title;
+  final List<Widget>? actions;
+
+  const InstructorDashboardAppBar({
+    super.key,
+    required this.currentNav,
+    this.title,
+    this.actions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final courseTitle = context.read<LibraryState>().selectedCourse?.title;
+    final displayTitle = title ??
+        (courseTitle != null ? 'Learning Lab: $courseTitle' : 'Learning Lab');
+
+    return AppBar(
+      title: Text(displayTitle),
+      actions: [
+        IconButton(
+          onPressed: () => NavigationEnum.home.navigateClean(context),
+          icon: const Icon(Icons.swap_horiz),
+        ),
+        ...?actions,
+      ],
+      bottom: InstructorDashboardTabBar(currentNav: currentNav),
+    );
+  }
+
+  @override
+  Size get preferredSize =>
+      const Size.fromHeight(kToolbarHeight + kTextTabBarHeight);
+}

--- a/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
+++ b/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+/// Navigation tab bar for the instructor flow pages.
+class InstructorDashboardTabBar extends StatefulWidget
+    implements PreferredSizeWidget {
+  final NavigationEnum currentNav;
+
+  const InstructorDashboardTabBar({
+    super.key,
+    required this.currentNav,
+  });
+
+  static const List<_TabInfo> _tabs = [
+    _TabInfo(
+      icon: Icons.dashboard_outlined,
+      nav: NavigationEnum.instructorDashBoard,
+      label: 'Dashboard',
+    ),
+    _TabInfo(
+      icon: Icons.fact_check_outlined,
+      nav: NavigationEnum.instructorClipboard,
+      label: 'Coach Clipboard',
+    ),
+    _TabInfo(
+      icon: Icons.groups_outlined,
+      nav: NavigationEnum.sessionHost,
+      label: 'Host Session',
+    ),
+  ];
+
+  static int indexFromNav(NavigationEnum nav) {
+    final index = _tabs.indexWhere((t) => t.nav == nav);
+    return index == -1 ? 0 : index;
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
+
+  @override
+  State<InstructorDashboardTabBar> createState() =>
+      _InstructorDashboardTabBarState();
+}
+
+class _InstructorDashboardTabBarState extends State<InstructorDashboardTabBar>
+    with SingleTickerProviderStateMixin {
+  late final TabController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TabController(
+      length: InstructorDashboardTabBar._tabs.length,
+      vsync: this,
+      initialIndex: InstructorDashboardTabBar.indexFromNav(widget.currentNav),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant InstructorDashboardTabBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.currentNav != widget.currentNav) {
+      _controller.index =
+          InstructorDashboardTabBar.indexFromNav(widget.currentNav);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      controller: _controller,
+      isScrollable: true,
+      tabs: [
+        for (final tab in InstructorDashboardTabBar._tabs)
+          Tab(
+            icon: Tooltip(
+              message: tab.label,
+              child: Icon(tab.icon),
+            ),
+          ),
+      ],
+      onTap: (index) {
+        final targetNav = InstructorDashboardTabBar._tabs[index].nav;
+        if (targetNav != widget.currentNav) {
+          targetNav.navigateClean(context);
+        }
+      },
+    );
+  }
+}
+
+class _TabInfo {
+  final IconData icon;
+  final NavigationEnum nav;
+  final String label;
+
+  const _TabInfo({
+    required this.icon,
+    required this.nav,
+    required this.label,
+  });
+}
+

--- a/lib/ui_foundation/instructor_dashboard_page.dart
+++ b/lib/ui_foundation/instructor_dashboard_page.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
-import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_roster_widget.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_summary_widget.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 
 class InstructorDashboardPage extends StatefulWidget {
   const InstructorDashboardPage({super.key});
@@ -19,7 +20,9 @@ class InstructorDashboardState extends State<InstructorDashboardPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const LearningLabAppBar(),
+      appBar: const InstructorDashboardAppBar(
+        currentNav: NavigationEnum.instructorDashBoard,
+      ),
       bottomNavigationBar: BottomBarV2.build(context),
       body: Align(
         alignment: Alignment.topCenter,


### PR DESCRIPTION
## Summary
- restore the clipboard page to the shared LearningLabAppBar so it no longer renders the instructor dashboard navigation tabs
- revert the session host page to the shared LearningLabAppBar to keep the top navigation exclusive to the dashboard screen

## Testing
- not run (Flutter SDK unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d6e2eb71c0832e9f0a3fab88c17e9a