### PR TITLE
Align course analytics queries with existing helpers

### DIFF
--- a/lib/data/data_helpers/practice_record_functions.dart
+++ b/lib/data/data_helpers/practice_record_functions.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:social_learning/data/course.dart';
 import 'package:social_learning/data/firestore_service.dart';
 import 'package:social_learning/data/practice_record.dart';
 
@@ -56,5 +57,16 @@ class PracticeRecordFunctions {
     return snapshot.docs
         .map((doc) => PracticeRecord.fromSnapshot(doc))
         .toList();
+  }
+
+  static Query<Map<String, dynamic>>
+      practiceRecordsForCourseAndMenteesQuery(
+    CollectionReference<Map<String, dynamic>> practiceRecordsCollection,
+    Course course,
+    List<String> menteeUids,
+  ) {
+    return practiceRecordsCollection
+        .where('courseId', isEqualTo: course.docRef)
+        .where('menteeUid', whereIn: menteeUids);
   }
 }

--- a/lib/data/data_helpers/user_functions.dart
+++ b/lib/data/data_helpers/user_functions.dart
@@ -97,6 +97,17 @@ class UserFunctions {
     return users;
   }
 
+  static Query<Map<String, dynamic>> recentActiveUsersForCourseQuery(
+    CollectionReference<Map<String, dynamic>> usersCollection,
+    Course course,
+    int maxUsers,
+  ) {
+    return usersCollection
+        .where('enrolledCourseIds', arrayContains: course.docRef)
+        .orderBy('lastLessonTimestamp', descending: true)
+        .limit(maxUsers);
+  }
+
   static Future<User> getCurrentUser() async {
     String uid = auth.FirebaseAuth.instance.currentUser!.uid;
     var snapshot = await FirestoreService.instance

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:social_learning/state/organizer_session_state.dart';
 import 'package:social_learning/state/student_session_state.dart';
 import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/state/course_designer_state.dart';
+import 'package:social_learning/state/course_analytics_state.dart';
 import 'package:social_learning/ui_foundation/cms_detail_page.dart';
 import 'package:social_learning/ui_foundation/cms_home_page.dart';
 import 'package:social_learning/ui_foundation/cms_lesson_page.dart';
@@ -76,6 +77,8 @@ void main() async {
   ApplicationState applicationState = ApplicationState();
   LibraryState libraryState = LibraryState(applicationState);
   CourseDesignerState courseDesignerState = CourseDesignerState(libraryState);
+  CourseAnalyticsState courseAnalyticsState =
+      CourseAnalyticsState(applicationState, libraryState);
 
   unawaited(libraryState.initialize());
 
@@ -88,6 +91,7 @@ void main() async {
       ChangeNotifierProvider(create: (context) => applicationState),
       ChangeNotifierProvider(create: (context) => libraryState),
       ChangeNotifierProvider(create: (context) => courseDesignerState),
+      ChangeNotifierProvider(create: (context) => courseAnalyticsState),
       ChangeNotifierProvider(
           create: (context) => StudentState(applicationState, libraryState)),
       ChangeNotifierProvider(

--- a/lib/state/application_state.dart
+++ b/lib/state/application_state.dart
@@ -14,6 +14,7 @@ import 'package:social_learning/state/online_session_state.dart';
 import 'package:social_learning/state/organizer_session_state.dart';
 import 'package:social_learning/state/student_session_state.dart';
 import 'package:social_learning/state/student_state.dart';
+import 'package:social_learning/state/course_analytics_state.dart';
 
 class ApplicationState extends ChangeNotifier {
   ApplicationState() {
@@ -172,7 +173,7 @@ class ApplicationState extends ChangeNotifier {
     notifyListeners();
   }
 
-  void signOut(BuildContext context) {
+  Future<void> signOut(BuildContext context) async {
     print('Start signOut');
     auth.FirebaseAuth.instance.signOut();
     print('FirebaseAuth signOut done');
@@ -197,6 +198,10 @@ class ApplicationState extends ChangeNotifier {
     StudentSessionState studentSessionState =
         Provider.of<StudentSessionState>(context, listen: false);
     studentSessionState.signOut();
+
+    CourseAnalyticsState courseAnalyticsState =
+        Provider.of<CourseAnalyticsState>(context, listen: false);
+    await courseAnalyticsState.signOut();
 
     OrganizerSessionState organizerSessionState =
         Provider.of<OrganizerSessionState>(context, listen: false);

--- a/lib/state/course_analytics_state.dart
+++ b/lib/state/course_analytics_state.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/practice_record.dart';
+import 'package:social_learning/data/user.dart';
+import 'package:social_learning/state/application_state.dart';
+import 'package:social_learning/state/firestore_subscription/course_analytics_practice_records_subscription.dart';
+import 'package:social_learning/state/firestore_subscription/course_analytics_users_subscription.dart';
+import 'package:social_learning/state/library_state.dart';
+
+class CourseAnalyticsState extends ChangeNotifier {
+  static const int _maxRecentUsers = 30;
+  static const Duration _autoDisposeDuration = Duration(hours: 1);
+
+  final ApplicationState _applicationState;
+  final LibraryState _libraryState;
+
+  final List<User> _courseUsers = [];
+  final List<PracticeRecord> _practiceRecords = [];
+
+  CourseAnalyticsUsersSubscription? _userSubscription;
+  CourseAnalyticsPracticeRecordsSubscription? _practiceRecordSubscription;
+
+  Future<void>? _initializationFuture;
+  Timer? _disposeTimer;
+  bool _isInitializing = false;
+  bool _isInitialized = false;
+  bool _hasAccess = false;
+  String? _activeCourseId;
+  bool _isDisposed = false;
+  int _generation = 0;
+
+  CourseAnalyticsState(this._applicationState, this._libraryState) {
+    _libraryState.addListener(_handleLibraryStateChange);
+  }
+
+  bool get hasAccess => _hasAccess;
+  bool get isInitialized => _isInitialized;
+
+  Future<UnmodifiableListView<User>> getCourseUsers() async {
+    await ensureInitialized();
+    return UnmodifiableListView<User>(_courseUsers);
+  }
+
+  Future<UnmodifiableListView<PracticeRecord>> getPracticeRecords() async {
+    await ensureInitialized();
+    return UnmodifiableListView<PracticeRecord>(_practiceRecords);
+  }
+
+  Future<void> ensureInitialized() {
+    if (_isDisposed) {
+      return Future.error(
+        StateError('CourseAnalyticsState has been disposed.'),
+      );
+    }
+
+    if (_isInitialized) {
+      return Future.value();
+    }
+
+    if (_initializationFuture != null) {
+      return _initializationFuture!;
+    }
+
+    final int generation = _generation;
+    _initializationFuture = _initialize(generation);
+    return _initializationFuture!;
+  }
+
+  Future<void> _initialize(int generation) async {
+    _isInitializing = true;
+    try {
+      final Course? course = _libraryState.selectedCourse;
+      final User? user = await _applicationState.currentUserBlocking;
+
+      if (generation != _generation) {
+        return;
+      }
+
+      if (course == null || course.id == null || user == null) {
+        await _resetState();
+        _hasAccess = false;
+        return;
+      }
+
+      final bool isCourseOwner = course.creatorId == user.uid;
+      _hasAccess = user.isAdmin || isCourseOwner;
+      if (!_hasAccess) {
+        await _resetState();
+        _activeCourseId = course.id;
+        return;
+      }
+
+      _activeCourseId = course.id;
+
+      _userSubscription ??= CourseAnalyticsUsersSubscription(
+        notifyListeners,
+        _handleUsersChanged,
+      );
+      _practiceRecordSubscription ??=
+          CourseAnalyticsPracticeRecordsSubscription(
+        notifyListeners,
+        _handlePracticeRecordsChanged,
+      );
+
+      await _userSubscription!.listenForCourse(course, _maxRecentUsers);
+      if (generation != _generation) {
+        return;
+      }
+
+      final List<String> menteeUids = _recentMenteeUids();
+      await _practiceRecordSubscription!
+          .listenForCourseAndMentees(course, menteeUids);
+      if (generation != _generation) {
+        return;
+      }
+
+      _isInitialized = true;
+      _scheduleAutoDispose();
+    } finally {
+      if (generation == _generation) {
+        _initializationFuture = null;
+      }
+      _isInitializing = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deinitialize() async {
+    _generation++;
+    _disposeTimer?.cancel();
+    _disposeTimer = null;
+
+    await _resetState();
+
+    _activeCourseId = null;
+    _hasAccess = false;
+    _isInitialized = false;
+    _isInitializing = false;
+    _initializationFuture = null;
+
+    notifyListeners();
+  }
+
+  Future<void> signOut() {
+    return deinitialize();
+  }
+
+  void _handleLibraryStateChange() {
+    if (!_isInitialized) {
+      return;
+    }
+
+    final String? selectedCourseId = _libraryState.selectedCourse?.id;
+    if (selectedCourseId != _activeCourseId) {
+      unawaited(deinitialize());
+    }
+  }
+
+  void _scheduleAutoDispose() {
+    _disposeTimer?.cancel();
+    _disposeTimer = Timer(_autoDisposeDuration, () {
+      unawaited(deinitialize());
+    });
+  }
+
+  void _handleUsersChanged(List<User> users) {
+    if (_isDisposed) {
+      return;
+    }
+
+    _courseUsers
+      ..clear()
+      ..addAll(users);
+
+    if (_isInitializing || !_hasAccess) {
+      return;
+    }
+
+    final Course? course = _libraryState.selectedCourse;
+    if (course == null || course.id == null) {
+      return;
+    }
+
+    unawaited(_practiceRecordSubscription
+        ?.listenForCourseAndMentees(course, _recentMenteeUids()));
+  }
+
+  void _handlePracticeRecordsChanged(List<PracticeRecord> records) {
+    if (_isDisposed) {
+      return;
+    }
+
+    _practiceRecords
+      ..clear()
+      ..addAll(records);
+  }
+
+  List<String> _recentMenteeUids() {
+    return _courseUsers
+        .map((user) => user.uid)
+        .where((uid) => uid.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Future<void> _resetState() async {
+    await _userSubscription?.cancel();
+    await _practiceRecordSubscription?.cancel();
+    _courseUsers.clear();
+    _practiceRecords.clear();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _libraryState.removeListener(_handleLibraryStateChange);
+    _disposeTimer?.cancel();
+    _disposeTimer = null;
+    _userSubscription?.cancel();
+    _userSubscription = null;
+    _practiceRecordSubscription?.cancel();
+    _practiceRecordSubscription = null;
+    super.dispose();
+  }
+}

--- a/lib/state/firestore_subscription/course_analytics_practice_records_subscription.dart
+++ b/lib/state/firestore_subscription/course_analytics_practice_records_subscription.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/practice_record.dart';
+import 'package:social_learning/data/data_helpers/practice_record_functions.dart';
+import 'package:social_learning/state/firestore_subscription/firestore_list_subscription.dart';
+
+class CourseAnalyticsPracticeRecordsSubscription
+    extends FirestoreListSubscription<PracticeRecord> {
+  CourseAnalyticsPracticeRecordsSubscription(
+    Function() notifyChange,
+    this._onRecordsChanged,
+  ) : super(
+          'practiceRecords',
+          (snapshot) => PracticeRecord.fromSnapshot(snapshot),
+          notifyChange,
+        );
+
+  final void Function(List<PracticeRecord>) _onRecordsChanged;
+  Completer<void>? _readyCompleter;
+
+  Future<void> listenForCourseAndMentees(
+    Course course,
+    List<String> menteeUids,
+  ) {
+    if (menteeUids.isEmpty) {
+      return cancelAndClear();
+    }
+
+    _readyCompleter = Completer<void>();
+    super.resubscribe(
+      (collection) =>
+          PracticeRecordFunctions.practiceRecordsForCourseAndMenteesQuery(
+        collection,
+        course,
+        menteeUids,
+      ),
+    );
+    return _readyCompleter!.future;
+  }
+
+  Future<void> cancelAndClear() async {
+    _onRecordsChanged(const []);
+    await super.cancel();
+    if (_readyCompleter != null && !_readyCompleter!.isCompleted) {
+      _readyCompleter!.complete();
+    }
+    _readyCompleter = null;
+  }
+
+  @override
+  void postProcess(List<PracticeRecord> items) {
+    _onRecordsChanged(List<PracticeRecord>.unmodifiable(items));
+    if (_readyCompleter != null && !_readyCompleter!.isCompleted) {
+      _readyCompleter!.complete();
+    }
+    super.postProcess(items);
+  }
+
+  @override
+  Future<void> cancel() async {
+    await cancelAndClear();
+  }
+}

--- a/lib/state/firestore_subscription/course_analytics_users_subscription.dart
+++ b/lib/state/firestore_subscription/course_analytics_users_subscription.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:social_learning/data/course.dart';
+import 'package:social_learning/data/user.dart';
+import 'package:social_learning/data/data_helpers/user_functions.dart';
+import 'package:social_learning/state/firestore_subscription/firestore_list_subscription.dart';
+
+class CourseAnalyticsUsersSubscription extends FirestoreListSubscription<User> {
+  CourseAnalyticsUsersSubscription(
+    Function() notifyChange,
+    this._onUsersChanged,
+  ) : super(
+          'users',
+          (snapshot) => User.fromSnapshot(snapshot),
+          notifyChange,
+        );
+
+  final void Function(List<User>) _onUsersChanged;
+  Completer<void>? _readyCompleter;
+
+  Future<void> listenForCourse(Course course, int maxUsers) {
+    _readyCompleter = Completer<void>();
+    super.resubscribe(
+      (collection) => UserFunctions.recentActiveUsersForCourseQuery(
+        collection,
+        course,
+        maxUsers,
+      ),
+    );
+    return _readyCompleter!.future;
+  }
+
+  @override
+  void postProcess(List<User> items) {
+    _onUsersChanged(List<User>.unmodifiable(items));
+    if (_readyCompleter != null && !_readyCompleter!.isCompleted) {
+      _readyCompleter!.complete();
+    }
+    super.postProcess(items);
+  }
+
+  @override
+  Future<void> cancel() async {
+    await super.cancel();
+    if (_readyCompleter != null && !_readyCompleter!.isCompleted) {
+      _readyCompleter!.complete();
+    }
+    _readyCompleter = null;
+  }
+}

--- a/lib/ui_foundation/sign_out_page.dart
+++ b/lib/ui_foundation/sign_out_page.dart
@@ -13,14 +13,14 @@ class SignOutPage extends StatelessWidget {
       children: [
         const Text("Successfully signed out!"),
         TextButton(
-            onPressed: () {
+            onPressed: () async {
               ApplicationState applicationState =
                   Provider.of<ApplicationState>(context, listen: false);
               Navigator.pushNamedAndRemoveUntil(
                   context,
                   NavigationEnum.landing.route,
                       (Route<dynamic> route) => false);
-              applicationState.signOut(context);
+              await applicationState.signOut(context);
             },
             child: const Text("Ghost myself"))
       ],


### PR DESCRIPTION
## Summary
- route course analytics Firestore queries through existing UserFunctions and PracticeRecordFunctions helpers to respect the XxxFunctions convention
- overhaul CourseAnalyticsState to await initial subscription snapshots, guard data access behind ensureInitialized, and handle teardown safely
- make application sign-out await the analytics teardown to keep state consistent

## Testing
- not run (Flutter CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d6e610c8bc832e83c04126a2f84c48