### PR TITLE
Keep playground text field focused after submissions

### DIFF
--- a/lib/ui_foundation/playground_page.dart
+++ b/lib/ui_foundation/playground_page.dart
@@ -14,6 +14,16 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   final ScrollController _scrollController = ScrollController();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _textFocusNode.requestFocus();
+      }
+    });
+  }
+
+  @override
   void dispose() {
     _textController.dispose();
     _textFocusNode.dispose();
@@ -25,7 +35,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
     final String value = rawValue.trim();
     if (value.isEmpty) {
       _textController.clear();
-      _textFocusNode.requestFocus();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _textFocusNode.requestFocus();
+        }
+      });
       return;
     }
 
@@ -34,7 +48,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
     });
 
     _textController.clear();
-    _textFocusNode.requestFocus();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _textFocusNode.requestFocus();
+      }
+    });
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scrollController.hasClients) {


### PR DESCRIPTION
## Summary
- ensure the playground text field requests focus after submissions using post-frame callbacks
- request focus when the playground page is created so it stays active after rebuilds

## Testing
- flutter analyze *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d714b6a170832ea424e78e00a24c30