### PR TITLE
Add performance tests for session pairing algorithm

### DIFF
--- a/test/session_pairing_algorithm_performance_test.dart
+++ b/test/session_pairing_algorithm_performance_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:social_learning/data/lesson.dart';
+import 'package:social_learning/session_pairing/session_pairing_algorithm.dart';
+import 'package:social_learning/session_pairing/testing/application_state_mock.dart';
+import 'package:social_learning/session_pairing/testing/library_state_mock.dart';
+import 'package:social_learning/session_pairing/testing/organizer_session_state_mock.dart';
+
+class SessionPairingAlgorithmPerformanceTest {
+  final SessionPairingAlgorithm _algorithm = SessionPairingAlgorithm();
+
+  void runForStudentCount(int studentCount) {
+    final applicationState = ApplicationStateMock();
+    final libraryState = LibraryStateMock(studentCount);
+    final organizerSessionState =
+        OrganizerSessionStateMock(applicationState, libraryState);
+
+    final List<Lesson> lessons = List<Lesson>.from(libraryState.lessons ?? []);
+    final Lesson? graduatedLesson = lessons.isNotEmpty ? lessons.first : null;
+
+    final int graduatedStudentCount = studentCount ~/ 2;
+    for (int i = 0; i < studentCount; i++) {
+      final hasGraduated = i < graduatedStudentCount;
+      final graduatedLessons =
+          (hasGraduated && graduatedLesson != null) ? [graduatedLesson] : <Lesson>[];
+      organizerSessionState.addTestUser(
+        'Student ${i + 1}',
+        false,
+        graduatedLessons,
+      );
+    }
+
+    final stopwatch = Stopwatch()..start();
+    final pairing =
+        _algorithm.generateNextSessionPairing(organizerSessionState, libraryState);
+    stopwatch.stop();
+
+    expect(pairing, isNotNull);
+
+    final elapsed = stopwatch.elapsed;
+    final elapsedMicroseconds = elapsed.inMicroseconds;
+    final elapsedMilliseconds = elapsed.inMilliseconds;
+    print(
+      'SessionPairingAlgorithm pairing with $studentCount students took '
+      '${elapsedMilliseconds}ms (${elapsedMicroseconds}µs)',
+    );
+  }
+}
+
+void main() {
+  final performanceTest = SessionPairingAlgorithmPerformanceTest();
+
+  for (int studentCount = 2; studentCount <= 20; studentCount++) {
+    test(
+        'SessionPairingAlgorithm performance with '
+        '$studentCount students', () {
+      performanceTest.runForStudentCount(studentCount);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated SessionPairingAlgorithmPerformanceTest to exercise the pairing algorithm
- cover scenarios with 2 through 20 students and ensure half have graduated one lesson
- print execution timing for each run to aid in investigating performance issues

## Testing
- not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc0e7ca49c832eac7cd168160eb691