### PR TITLE
Add student population analytics page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'package:social_learning/ui_foundation/online_session_active_page.dart';
 import 'package:social_learning/ui_foundation/online_session_review_page.dart';
 import 'package:social_learning/ui_foundation/online_session_waiting_room_page.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
+import 'package:social_learning/ui_foundation/student_population_analytics_page.dart';
 import 'package:social_learning/ui_foundation/playground_page.dart';
 import 'package:social_learning/ui_foundation/profile_comparison_page.dart';
 import 'package:social_learning/ui_foundation/session_create_page.dart';
@@ -181,6 +182,8 @@ class SocialLearningApp extends StatelessWidget {
         '/create_course': (context) => const CourseCreatePage(),
         '/code_of_conduct': (context) => const CodeOfConductPage(),
         '/instructor_dashboard': (context) => const InstructorDashboardPage(),
+        '/student_population_analytics': (context) =>
+            const StudentPopulationAnalyticsPage(),
         '/instructor_clipboard': (context) => const InstructorClipboardPage(),
         '/create_skill_assessment': (context) =>
             const CreateSkillAssessmentPage(),

--- a/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
+++ b/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
@@ -17,6 +17,11 @@ class InstructorDashboardTabBar extends StatefulWidget
       nav: NavigationEnum.instructorDashBoard,
       label: 'Dashboard',
     ),
+    _TabInfo(
+      icon: Icons.people_outline,
+      nav: NavigationEnum.studentPopulationAnalytics,
+      label: 'Student Analytics',
+    ),
   ];
 
   static int indexFromNav(NavigationEnum nav) {

--- a/lib/ui_foundation/student_population_analytics_page.dart
+++ b/lib/ui_foundation/student_population_analytics_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_app_bar.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+class StudentPopulationAnalyticsPage extends StatelessWidget {
+  const StudentPopulationAnalyticsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const InstructorDashboardAppBar(
+        currentNav: NavigationEnum.studentPopulationAnalytics,
+        title: 'Student Population Analytics',
+      ),
+      bottomNavigationBar: BottomBarV2.build(context),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: CustomUiConstants.framePage(
+          const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Hello World'),
+            ],
+          ),
+          enableCourseLoadingGuard: true,
+          enableCreatorGuard: true,
+          enableCourseAnalyticsGuard: true,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/ui_constants/navigation_enum.dart
+++ b/lib/ui_foundation/ui_constants/navigation_enum.dart
@@ -28,6 +28,7 @@ enum NavigationEnum {
   codeOfConduct('/code_of_conduct'),
   onlineSessionReview('/online_session_review'),
   instructorDashBoard('/instructor_dashboard'),
+  studentPopulationAnalytics('/student_population_analytics'),
   instructorClipboard('/instructor_clipboard'),
   createSkillAssessment('/create_skill_assessment'),
   viewSkillAssessment('/view_skill_assessment'),


### PR DESCRIPTION
## Summary
- add a StudentPopulationAnalyticsPage that uses the shared framePage layout with the required guards
- register the new page in navigation so it can be routed to from the instructor experience
- extend the instructor dashboard tab bar with a student analytics icon that links to the new page

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0f04d718832ea9d81082385ae8c6