### PR TITLE
Add study history analytics stub page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:social_learning/ui_foundation/online_session_review_page.dart';
 import 'package:social_learning/ui_foundation/online_session_waiting_room_page.dart';
 import 'package:social_learning/ui_foundation/other_profile_page.dart';
 import 'package:social_learning/ui_foundation/student_population_analytics_page.dart';
+import 'package:social_learning/ui_foundation/study_history_anlytics_page.dart';
 import 'package:social_learning/ui_foundation/playground_page.dart';
 import 'package:social_learning/ui_foundation/profile_comparison_page.dart';
 import 'package:social_learning/ui_foundation/session_create_page.dart';
@@ -184,6 +185,8 @@ class SocialLearningApp extends StatelessWidget {
         '/instructor_dashboard': (context) => const InstructorDashboardPage(),
         '/student_population_analytics': (context) =>
             const StudentPopulationAnalyticsPage(),
+        '/study_history_anlytics': (context) =>
+            const StudyHistoryAnlyticsPage(),
         '/instructor_clipboard': (context) => const InstructorClipboardPage(),
         '/create_skill_assessment': (context) =>
             const CreateSkillAssessmentPage(),

--- a/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
+++ b/lib/ui_foundation/helper_widgets/bottom_bar_v2.dart
@@ -155,6 +155,7 @@ class BottomBarV2 {
           NavigationEnum.cmsSyllabus.route,
           NavigationEnum.cmsLesson.route,
           NavigationEnum.instructorClipboard.route,
+          NavigationEnum.studyHistoryAnlytics.route,
           NavigationEnum.courseGeneration.route,
           NavigationEnum.courseGenerationReview.route,
           NavigationEnum.courseDesignerIntro.route,

--- a/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
+++ b/lib/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_tab_bar.dart
@@ -22,6 +22,11 @@ class InstructorDashboardTabBar extends StatefulWidget
       nav: NavigationEnum.studentPopulationAnalytics,
       label: 'Student Analytics',
     ),
+    _TabInfo(
+      icon: Icons.history,
+      nav: NavigationEnum.studyHistoryAnlytics,
+      label: 'Study History',
+    ),
   ];
 
   static int indexFromNav(NavigationEnum nav) {

--- a/lib/ui_foundation/study_history_anlytics_page.dart
+++ b/lib/ui_foundation/study_history_anlytics_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
+import 'package:social_learning/ui_foundation/helper_widgets/instructor_dashboard/instructor_dashboard_app_bar.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
+
+class StudyHistoryAnlyticsPage extends StatelessWidget {
+  const StudyHistoryAnlyticsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const InstructorDashboardAppBar(
+        currentNav: NavigationEnum.studyHistoryAnlytics,
+        title: 'Study History Analytics',
+      ),
+      bottomNavigationBar: BottomBarV2.build(context),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: CustomUiConstants.framePage(
+          const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Hello World'),
+            ],
+          ),
+          enableCourseLoadingGuard: true,
+          enableCreatorGuard: true,
+          enableCourseAnalyticsGuard: true,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_foundation/ui_constants/navigation_enum.dart
+++ b/lib/ui_foundation/ui_constants/navigation_enum.dart
@@ -29,6 +29,7 @@ enum NavigationEnum {
   onlineSessionReview('/online_session_review'),
   instructorDashBoard('/instructor_dashboard'),
   studentPopulationAnalytics('/student_population_analytics'),
+  studyHistoryAnlytics('/study_history_anlytics'),
   instructorClipboard('/instructor_clipboard'),
   createSkillAssessment('/create_skill_assessment'),
   viewSkillAssessment('/view_skill_assessment'),


### PR DESCRIPTION
## Summary
- add a Study History Analytics stub page matching the instructor analytics layout
- register the new route with navigation enums, the instructor dashboard tab bar, and the bottom navigation manage section

## Testing
- flutter analyze *(fails: Flutter SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc15a36808832e94727a7b24f80e70