### PR TITLE
Fix fl_chart API usage for student population analytics chart

### DIFF
--- a/lib/ui_foundation/student_population_analytics_page.dart
+++ b/lib/ui_foundation/student_population_analytics_page.dart
@@ -166,7 +166,6 @@ class StudentPopulationAnalyticsPage extends StatelessWidget {
           }
 
           return SideTitleWidget(
-            axisSide: meta.axisSide,
             space: 12,
             meta: meta,
             child: RotatedBox(
@@ -196,7 +195,6 @@ class StudentPopulationAnalyticsPage extends StatelessWidget {
             return const SizedBox.shrink();
           }
           return SideTitleWidget(
-            axisSide: meta.axisSide,
             space: 8,
             meta: meta,
             child: Text(
@@ -235,7 +233,8 @@ class StudentPopulationAnalyticsPage extends StatelessWidget {
     return LineTouchData(
       handleBuiltInTouches: true,
       touchTooltipData: LineTouchTooltipData(
-        tooltipBgColor: theme.colorScheme.surfaceVariant.withOpacity(0.95),
+        getTooltipColor: (touchedSpot) =>
+            theme.colorScheme.surfaceVariant.withOpacity(0.95),
         getTooltipItems: (touchedSpots) {
           if (touchedSpots.isEmpty) {
             return [];


### PR DESCRIPTION
## Summary
- update the student population analytics chart to match the latest fl_chart APIs
- remove usage of the deprecated SideTitleWidget.axisSide parameter
- provide the tooltip color via the new LineTouchTooltipData.getTooltipColor callback

## Testing
- Not run (Flutter SDK unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc44c836bc832eb53ba2d9855f71f9