### PR TITLE
Fix invalid custom UI constants imports

### DIFF
--- a/lib/ui_foundation/cms_syllabus_page.dart
+++ b/lib/ui_foundation/cms_syllabus_page.dart
@@ -10,7 +10,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/course_designer/cou
 import 'package:social_learning/ui_foundation/helper_widgets/edit_level_title_dialog.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/one_time_banner.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/course_designer_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/cms_syllabus/edit_invitation_code_dialog.dart';

--- a/lib/ui_foundation/home_page.dart
+++ b/lib/ui_foundation/home_page.dart
@@ -8,7 +8,7 @@ import 'package:social_learning/state/library_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'ui_constants/navigation_enum.dart';

--- a/lib/ui_foundation/level_detail_page.dart
+++ b/lib/ui_foundation/level_detail_page.dart
@@ -7,7 +7,7 @@ import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/lesson_detail_page.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 

--- a/lib/ui_foundation/level_list_page.dart
+++ b/lib/ui_foundation/level_list_page.dart
@@ -9,7 +9,7 @@ import 'package:social_learning/state/student_state.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/level_detail_page.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 

--- a/lib/ui_foundation/profile_page.dart
+++ b/lib/ui_foundation/profile_page.dart
@@ -15,7 +15,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/profile_progress_vi
 import 'package:social_learning/ui_foundation/helper_widgets/profile_text_editor.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/value_input_dialog.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/user_profile_widgets/profile_image_widget_v2.dart';
 import 'package:social_learning/data/user.dart';
 import 'package:social_learning/data/course.dart';

--- a/lib/ui_foundation/session_host_page.dart
+++ b/lib/ui_foundation/session_host_page.dart
@@ -16,7 +16,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/lesson_table_cell.d
 import 'package:social_learning/ui_foundation/helper_widgets/mentee_table_cell.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/mentor_table_cell.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
 import 'package:social_learning/ui_foundation/ui_constants/navigation_enum.dart';
 

--- a/lib/ui_foundation/session_student_page.dart
+++ b/lib/ui_foundation/session_student_page.dart
@@ -8,7 +8,7 @@ import 'package:social_learning/ui_foundation/helper_widgets/bottom_bar_v2.dart'
 import 'package:social_learning/ui_foundation/helper_widgets/general/learning_lab_app_bar.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/session_round_card.dart';
 import 'package:social_learning/ui_foundation/helper_widgets/dialog_utils.dart';
-import 'package:social_learning/ui_foundation/ui_constants//custom_ui_constants.dart';
+import 'package:social_learning/ui_foundation/ui_constants/custom_ui_constants.dart';
 import 'package:social_learning/ui_foundation/ui_constants/custom_text_styles.dart';
 
 class SessionStudentArgument {


### PR DESCRIPTION
## Summary
- correct several page imports so they reference `custom_ui_constants.dart` with a valid package URI
- ensure pages that rely on shared UI constants compile without missing library errors

## Testing
- not run (flutter unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc4e3e97fc832ebb202e33129bdc66