### PR TITLE
Fix line chart tooltip item count mismatch

### DIFF
--- a/lib/ui_foundation/student_population_analytics_page.dart
+++ b/lib/ui_foundation/student_population_analytics_page.dart
@@ -244,15 +244,23 @@ class StudentPopulationAnalyticsPage extends StatelessWidget {
           if (touchedSpots.isEmpty) {
             return [];
           }
-          final index = touchedSpots.first.x.toInt().clamp(0, rows.length - 1);
-          final row = rows[index];
 
-          return [
-            LineTooltipItem(
+          return touchedSpots.map((spot) {
+            final index = spot.x.toInt().clamp(0, rows.length - 1);
+            final row = rows[index];
+
+            if (spot.barIndex == 0) {
+              return LineTooltipItem(
+                'Graduated: ${row.graduationCount}',
+                tooltipStyle,
+              );
+            }
+
+            return LineTooltipItem(
               '${row.lesson.title}\nPracticed: ${row.totalCount}\nGraduated: ${row.graduationCount}',
               tooltipStyle,
-            ),
-          ];
+            );
+          }).toList();
         },
       ),
     );


### PR DESCRIPTION
## Summary
- ensure the line chart tooltip returns an item for every touched spot
- show separate tooltip entries for the graduated and practiced datasets

## Testing
- not run (flutter analyze)

------
https://chatgpt.com/codex/tasks/task_e_68dc5665a530832e8b5fd8cf61add030