### PR TITLE
Filter bootstrap records from study history analytics

### DIFF
--- a/lib/ui_foundation/study_history_anlytics_page.dart
+++ b/lib/ui_foundation/study_history_anlytics_page.dart
@@ -277,7 +277,7 @@ class StudyHistoryAnlyticsPage extends StatelessWidget {
         context.watch<CourseAnalyticsState>();
 
     UnmodifiableListView<PracticeRecord> practiceRecords =
-        await courseAnalyticsState.getPracticeRecords();
+        UnmodifiableListView(await courseAnalyticsState.getActualPracticeRecords());
 
     final Map<DateTime, _DayDataRow> dayToRow = {};
 


### PR DESCRIPTION
## Summary
- ensure the study history analytics chart filters out bootstrap mentor records by reusing the actual practice record helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc736bcb98832eb329a27da3d4d080