### PR TITLE
Sync party pairing host FAB with InProcessPartyPairingService state and stop service on session end

### DIFF
--- a/lib/session_pairing/party_pairing_service/in_process_party_pairing_service.dart
+++ b/lib/session_pairing/party_pairing_service/in_process_party_pairing_service.dart
@@ -22,6 +22,8 @@ class InProcessPartyPairingService extends ChangeNotifier {
     this._organizerSessionState,
   );
 
+  bool get isRunning => _isRunning;
+
   void startService() {
     if (_isRunning) {
       return;
@@ -34,6 +36,7 @@ class InProcessPartyPairingService extends ChangeNotifier {
     _doIncrementalPairingGuard();
 
     print('Started InProcessPartyPairingService.');
+    notifyListeners();
   }
 
   void stopService() {
@@ -41,6 +44,7 @@ class InProcessPartyPairingService extends ChangeNotifier {
     _isRunning = false;
 
     print('Stopped InProcessPartyPairingService.');
+    notifyListeners();
   }
 
   void _doIncrementalPairingGuard() {

--- a/lib/ui_foundation/party_pairing_host_page.dart
+++ b/lib/ui_foundation/party_pairing_host_page.dart
@@ -21,8 +21,6 @@ class PartyPairingHostPage extends StatefulWidget {
 }
 
 class _PartyPairingHostPageState extends State<PartyPairingHostPage> {
-  bool _isPairingPaused = true;
-
   @override
   Widget build(BuildContext context) {
     OrganizerSessionState organizerSessionState = context
@@ -61,8 +59,11 @@ class _PartyPairingHostPageState extends State<PartyPairingHostPage> {
   }
 
   Widget _buildFloatingActionButton(BuildContext context) {
-    IconData pairingIcon = _isPairingPaused ? Icons.play_arrow : Icons.pause;
-    String pairingLabel = _isPairingPaused ? 'Start pairing' : 'Pause pairing';
+    InProcessPartyPairingService inProcessPartyPairingService = context
+        .watch<InProcessPartyPairingService>();
+    bool isPairingPaused = !inProcessPartyPairingService.isRunning;
+    IconData pairingIcon = isPairingPaused ? Icons.play_arrow : Icons.pause;
+    String pairingLabel = isPairingPaused ? 'Start pairing' : 'Pause pairing';
 
     return SpeedDial(
       icon: Icons.more_vert,
@@ -83,14 +84,10 @@ class _PartyPairingHostPageState extends State<PartyPairingHostPage> {
   }
 
   void _togglePairing() {
-    setState(() {
-      _isPairingPaused = !_isPairingPaused;
-    });
-
     InProcessPartyPairingService inProcessPartyPairingService = context
         .read<InProcessPartyPairingService>();
 
-    if (_isPairingPaused) {
+    if (inProcessPartyPairingService.isRunning) {
       inProcessPartyPairingService.stopService();
     } else {
       inProcessPartyPairingService.startService();
@@ -105,6 +102,7 @@ class _PartyPairingHostPageState extends State<PartyPairingHostPage> {
       () {
         OrganizerSessionState organizerSessionState =
             Provider.of<OrganizerSessionState>(context, listen: false);
+        context.read<InProcessPartyPairingService>().stopService();
         organizerSessionState.endSession();
 
         Navigator.pushNamed(context, NavigationEnum.sessionHome.route);


### PR DESCRIPTION
### Motivation
- Ensure the Party Pairing host UI reflects the actual pairing service state and that the pairing service is stopped when a session is ended to avoid background pairing after session shutdown.

### Description
- Added an `isRunning` getter and `notifyListeners()` calls to `InProcessPartyPairingService` so consumers can react to start/stop changes at runtime via `ChangeNotifier`.
- Updated the host page to watch `InProcessPartyPairingService` and derive the FAB icon/label from `isRunning` instead of using a local widget boolean, and toggled the service using `startService()`/`stopService()` via `context.read`.
- Ensured ending a session from the host page calls `context.read<InProcessPartyPairingService>().stopService()` before `OrganizerSessionState.endSession()`.

### Testing
- Attempted to run `flutter analyze`, but the `flutter` binary is not available in this environment so static analysis could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91efd4f34832eb3c2afd0085a8bd5)