### PR TITLE
Add CLI backfill for profile photo thumbnail/tiny variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,41 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Backfill existing profile photo sizes
+
+A command-line script now exists at `functions/src/scripts/backfillProfilePhotoSizes.ts` to create
+`profilePhotoThumbnail` (320px) and `profilePhotoTiny` (80px) objects for existing users.
+It also updates Firestore user fields:
+
+- `profileFireStoragePath`
+- `profileThumbnailFireStoragePath`
+- `profileTinyFireStoragePath`
+
+### Why this handles permissions safely
+
+The script uses the Firebase Admin SDK, so it runs with service-account IAM permissions and is
+not blocked by client-side Firebase Storage security rules that only allow users to write their own
+photos. This lets you run a one-time migration without weakening end-user storage rules.
+
+### Run
+
+1. Authenticate with a service account that has Storage Object Admin + Firestore write access.
+2. Dry run first:
+
+```bash
+npm --prefix functions run backfill:profile-photo-sizes -- --dry-run --limit=20
+```
+
+3. Write changes:
+
+```bash
+npm --prefix functions run backfill:profile-photo-sizes -- --write
+```
+
+Optional flags:
+
+- `--uid=<firebaseAuthUid>` process one user
+- `--start-after-uid=<firebaseAuthUid>` resume after a specific uid
+- `--limit=<n>` cap records processed in one run
+

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^6.0.1",
-        "openai": "^4.97.0"
+        "openai": "^4.97.0",
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -607,13 +608,11 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
-      "dev": true,
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1105,6 +1104,471 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3853,6 +4317,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -8541,9 +9014,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8681,6 +9154,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,8 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "backfill:profile-photo-sizes": "npm run build && node lib/scripts/backfillProfilePhotoSizes.js"
   },
   "engines": {
     "node": "22"
@@ -17,7 +18,8 @@
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
-    "openai": "^4.97.0"
+    "openai": "^4.97.0",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.40.0",

--- a/functions/src/scripts/backfillProfilePhotoSizes.ts
+++ b/functions/src/scripts/backfillProfilePhotoSizes.ts
@@ -1,0 +1,275 @@
+import * as admin from 'firebase-admin';
+import sharp from 'sharp';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+const storage = admin.storage();
+
+const THUMBNAIL_SIZE = 320;
+const TINY_SIZE = 80;
+const DEFAULT_DRY_RUN = true;
+
+type ScriptOptions = {
+  limit: number | null;
+  startAfterUid: string | null;
+  onlyUid: string | null;
+  dryRun: boolean;
+};
+
+type ProcessResult = {
+  uid: string;
+  status: 'updated' | 'skipped' | 'dry-run';
+  reason: string;
+  sourceSize?: number;
+  thumbnailSize?: number;
+  tinySize?: number;
+};
+
+function parseArgs(): ScriptOptions {
+  const rawArgs: string[] = process.argv.slice(2);
+  const options: ScriptOptions = {
+    limit: null,
+    startAfterUid: null,
+    onlyUid: null,
+    dryRun: DEFAULT_DRY_RUN,
+  };
+
+  for (const arg of rawArgs) {
+    if (arg === '--write') {
+      options.dryRun = false;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg.startsWith('--limit=')) {
+      const rawLimit: string = arg.split('=')[1];
+      const parsedLimit: number = Number(rawLimit);
+      if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+        throw new Error(`Invalid --limit value: ${rawLimit}`);
+      }
+      options.limit = parsedLimit;
+      continue;
+    }
+    if (arg.startsWith('--start-after-uid=')) {
+      options.startAfterUid = arg.split('=')[1];
+      continue;
+    }
+    if (arg.startsWith('--uid=')) {
+      options.onlyUid = arg.split('=')[1];
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function normalizeStoragePath(pathValue: string | null | undefined): string | null {
+  if (!pathValue) {
+    return null;
+  }
+  return pathValue.startsWith('/') ? pathValue.substring(1) : pathValue;
+}
+
+function profilePathsForUid(uid: string, userData: FirebaseFirestore.DocumentData): {
+  originalPath: string;
+  thumbnailPath: string;
+  tinyPath: string;
+  fullPathForFirestore: string;
+  thumbnailPathForFirestore: string;
+  tinyPathForFirestore: string;
+} {
+  const originalPath: string = normalizeStoragePath(userData.profileFireStoragePath) ||
+    `users/${uid}/profilePhoto`;
+  const thumbnailPath = `users/${uid}/profilePhotoThumbnail`;
+  const tinyPath = `users/${uid}/profilePhotoTiny`;
+
+  return {
+    originalPath,
+    thumbnailPath,
+    tinyPath,
+    fullPathForFirestore: `/${originalPath}`,
+    thumbnailPathForFirestore: `/${thumbnailPath}`,
+    tinyPathForFirestore: `/${tinyPath}`,
+  };
+}
+
+async function renderJpegVariant(sourceBytes: Buffer, size: number): Promise<Buffer> {
+  return sharp(sourceBytes)
+    .rotate()
+    .resize({
+      width: size,
+      height: size,
+      fit: 'inside',
+      withoutEnlargement: true,
+      kernel: sharp.kernel.lanczos3,
+    })
+    .jpeg({
+      quality: 100,
+      mozjpeg: true,
+      chromaSubsampling: '4:4:4',
+    })
+    .toBuffer();
+}
+
+async function loadUsers(
+  options: ScriptOptions,
+): Promise<FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>[]> {
+  if (options.onlyUid) {
+    const querySnapshot = await db
+      .collection('users')
+      .where('uid', '==', options.onlyUid)
+      .limit(1)
+      .get();
+    return querySnapshot.docs;
+  }
+
+  let query: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> =
+    db.collection('users').orderBy('uid');
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (!options.startAfterUid) {
+    const querySnapshot = await query.get();
+    return querySnapshot.docs;
+  }
+
+  const startSnapshot = await db
+    .collection('users')
+    .where('uid', '==', options.startAfterUid)
+    .limit(1)
+    .get();
+
+  if (startSnapshot.empty) {
+    throw new Error(`Could not find user for --start-after-uid=${options.startAfterUid}`);
+  }
+
+  const startUid: string = startSnapshot.docs[0].get('uid');
+  const pagedQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = query.startAfter(startUid);
+  const snapshot = await pagedQuery.get();
+  return snapshot.docs;
+}
+
+async function processUser(
+  userDoc: FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>,
+  options: ScriptOptions,
+): Promise<ProcessResult> {
+  const userData = userDoc.data();
+  const uid = userData.uid as string | undefined;
+
+  if (!uid) {
+    return {uid: '(missing-uid)', status: 'skipped', reason: 'missing uid field'};
+  }
+
+  const bucket = storage.bucket();
+  const paths = profilePathsForUid(uid, userData);
+  const originalFile = bucket.file(paths.originalPath);
+
+  const [exists] = await originalFile.exists();
+  if (!exists) {
+    return {uid, status: 'skipped', reason: `source file not found: ${paths.originalPath}`};
+  }
+
+  const [originalBytes, metadata] = await Promise.all([
+    originalFile.download().then((downloadResult) => downloadResult[0]),
+    originalFile.getMetadata().then((result) => result[0]),
+  ]);
+
+  const [thumbnailBytes, tinyBytes] = await Promise.all([
+    renderJpegVariant(originalBytes, THUMBNAIL_SIZE),
+    renderJpegVariant(originalBytes, TINY_SIZE),
+  ]);
+
+  if (options.dryRun) {
+    return {
+      uid,
+      status: 'dry-run',
+      reason: `would write ${paths.thumbnailPath} and ${paths.tinyPath}`,
+      sourceSize: originalBytes.length,
+      thumbnailSize: thumbnailBytes.length,
+      tinySize: tinyBytes.length,
+    };
+  }
+
+  await Promise.all([
+    bucket.file(paths.thumbnailPath).save(thumbnailBytes, {
+      resumable: false,
+      metadata: {
+        contentType: 'image/jpeg',
+        cacheControl: metadata.cacheControl || 'public,max-age=3600',
+      },
+    }),
+    bucket.file(paths.tinyPath).save(tinyBytes, {
+      resumable: false,
+      metadata: {
+        contentType: 'image/jpeg',
+        cacheControl: metadata.cacheControl || 'public,max-age=3600',
+      },
+    }),
+    userDoc.ref.set({
+      profileFireStoragePath: paths.fullPathForFirestore,
+      profileThumbnailFireStoragePath: paths.thumbnailPathForFirestore,
+      profileTinyFireStoragePath: paths.tinyPathForFirestore,
+    }, {merge: true}),
+  ]);
+
+  return {
+    uid,
+    status: 'updated',
+    reason: `wrote ${paths.thumbnailPath} and ${paths.tinyPath}`,
+    sourceSize: originalBytes.length,
+    thumbnailSize: thumbnailBytes.length,
+    tinySize: tinyBytes.length,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  const users = await loadUsers(options);
+
+  if (users.length === 0) {
+    console.log('No users found for the provided filters.');
+    return;
+  }
+
+  console.log(`Loaded ${users.length} users. dryRun=${options.dryRun}`);
+
+  const counters = {
+    updated: 0,
+    skipped: 0,
+    dryRun: 0,
+  };
+
+  for (const userDoc of users) {
+    const result = await processUser(userDoc, options);
+    if (result.status === 'updated') {
+      counters.updated += 1;
+    } else if (result.status === 'skipped') {
+      counters.skipped += 1;
+    } else {
+      counters.dryRun += 1;
+    }
+
+    console.log(
+      `[${result.status}] uid=${result.uid} ${result.reason}` +
+      (result.sourceSize ?
+        ` source=${result.sourceSize} thumb=${result.thumbnailSize} tiny=${result.tinySize}` :
+        ''),
+    );
+  }
+
+  console.log('Finished.');
+  console.log(JSON.stringify(counters, null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error('Backfill failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Provide a trusted backend migration to generate and store standardized profile photo variants (320px thumbnail and 80px tiny) for all existing users while keeping client-side Storage rules intact.
- Ensure high-quality resizing so avatars look good across devices and match the app's existing `profilePhoto` + `profilePhotoThumbnail` + `profilePhotoTiny` model.

### Description
- Add a TypeScript CLI script at `functions/src/scripts/backfillProfilePhotoSizes.ts` that scans Firestore `users`, reads each user's original profile image from Cloud Storage, produces 320px and 80px JPEG variants, uploads them to `users/<uid>/profilePhotoThumbnail` and `users/<uid>/profilePhotoTiny`, and updates Firestore fields `profileFireStoragePath`, `profileThumbnailFireStoragePath`, and `profileTinyFireStoragePath`.
- Use the Firebase Admin SDK so the operation runs with service-account IAM permissions (avoiding changes to client-side security rules) and use `sharp` for image processing with high-quality settings (`kernel: lanczos3`, `quality: 100`, `chromaSubsampling: '4:4:4'`, and `withoutEnlargement: true`).
- Add an npm helper script `backfill:profile-photo-sizes` in `functions/package.json` and add the `sharp` dependency to `functions/package.json` and `package-lock.json`.
- Document usage and flags (`--dry-run` default, `--write`, `--uid`, `--limit`, `--start-after-uid`) and the required service-account permissions in `README.md`.

### Testing
- Ran `npm --prefix functions run lint` on the modified code and it succeeded after converting the initial JS helper into TypeScript.
- Ran `npm --prefix functions run build` (`tsc`) and it completed successfully producing the compiled script under `lib/scripts`.
- Attempted to run the script in dry-run mode with `npm --prefix functions run backfill:profile-photo-sizes -- --dry-run --limit=1`, which failed in this environment due to missing Google Cloud/Firebase credentials (ADC/project id), which is expected when not authenticated with a service account.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d0edebd4832eba6b29e4cc1ddeb4)